### PR TITLE
Swathi | #3321 | Enhanced Bahmni Observation endpoint to retrieve revised obs with revision=latest parameter

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/ObsDao.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/ObsDao.java
@@ -34,6 +34,4 @@ public interface ObsDao {
     Obs getChildObsFromParent(String parentObsUuid, Concept childConcept);
 
     List<Obs> getObsByPatientProgramUuidAndConceptNames(String patientProgramUuid, List<String> conceptNames, Integer limit, ObsDaoImpl.OrderBy sortOrder, Date startDate, Date endDate);
-
-    Obs getRevisionObs(Obs initialObs);
 }

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/impl/ObsDaoImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/impl/ObsDaoImpl.java
@@ -328,12 +328,4 @@ public class ObsDaoImpl implements ObsDao {
 
         return queryToGetObs.list();
     }
-
-    @Override
-    public Obs getRevisionObs(Obs initialObs) {
-        return (Obs) sessionFactory.getCurrentSession()
-                .createQuery("from Obs o where o.previousVersion = :id")
-                .setString("id",initialObs.getId().toString())
-                .uniqueResult();
-    }
 }

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/BahmniObsService.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/BahmniObsService.java
@@ -31,6 +31,6 @@ public interface BahmniObsService {
     public Collection<BahmniObservation> getLatestObservationsForPatientProgram(String patientProgramUuid, List<String> conceptNames);
     public Collection<BahmniObservation> getInitialObservationsForPatientProgram(String patientProgramUuid, List<String> conceptNames);
 
-    BahmniObservation getBahmniObservationByUuid(String observationUuid, boolean getRevision);
-    Obs getRevisionObs(Obs initialObs);
+    BahmniObservation getBahmniObservationByUuid(String observationUuid);
+    BahmniObservation getRevisedBahmniObservationByUuid(String observationUuid);
 }

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImpl.java
@@ -229,17 +229,22 @@ public class BahmniObsServiceImpl implements BahmniObsService {
     }
 
     @Override
-    public BahmniObservation getBahmniObservationByUuid(String observationUuid, boolean getRevision) {
+    public BahmniObservation getBahmniObservationByUuid(String observationUuid) {
         Obs obs = obsService.getObsByUuid(observationUuid);
-        if (getRevision && obs.getVoided()) {
+        return omrsObsToBahmniObsMapper.map(obs);
+    }
+
+    @Override
+    public BahmniObservation getRevisedBahmniObservationByUuid(String observationUuid) {
+        Obs obs = obsService.getObsByUuid(observationUuid);
+        if (obs.getVoided()) {
             obs = getRevisionObs(obs);
         }
         return omrsObsToBahmniObsMapper.map(obs);
     }
 
-    @Override
-    public Obs getRevisionObs(Obs initialObs) {
-        Obs revisedObs = obsDao.getRevisionObs(initialObs);
+    private Obs getRevisionObs(Obs initialObs) {
+        Obs revisedObs = obsService.getRevisionObs(initialObs);
         if (revisedObs != null && revisedObs.getVoided()) {
             revisedObs = getRevisionObs(revisedObs);
         }

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplIT.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplIT.java
@@ -180,7 +180,7 @@ public class BahmniObsServiceImplIT extends BaseIntegrationTest {
 
     @Test
     public void shouldRetrieveBahmniObservationByObservationUuid() throws Exception {
-        BahmniObservation bahmniObservation = bahmniObsService.getBahmniObservationByUuid("633dc076-1c8f-11e4-bkk0-f18addb6fmtb", false);
+        BahmniObservation bahmniObservation = bahmniObsService.getBahmniObservationByUuid("633dc076-1c8f-11e4-bkk0-f18addb6fmtb");
 
         assertNotNull("BahmniObservation should not be null", bahmniObservation);
         assertEquals("633dc076-1c8f-11e4-bkk0-f18addb6fmtb", bahmniObservation.getUuid());
@@ -200,7 +200,7 @@ public class BahmniObsServiceImplIT extends BaseIntegrationTest {
     }
 
     public void shouldRetrieveRevisionBahmniObservationByObservationUuid() throws Exception {
-        BahmniObservation bahmniObservation = bahmniObsService.getBahmniObservationByUuid("uuid99998", true);
+        BahmniObservation bahmniObservation = bahmniObsService.getRevisedBahmniObservationByUuid("uuid99998");
 
         assertNotNull("BahmniObservation should not be null", bahmniObservation);
         assertEquals("uuid999982", bahmniObservation.getUuid());

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplTest.java
@@ -205,7 +205,7 @@ public class BahmniObsServiceImplTest {
         when(obsService.getObsByUuid(observationUuid)).thenReturn(obs);
         when(omrsObsToBahmniObsMapper.map(obs)).thenReturn(expectedBahmniObservation);
 
-        BahmniObservation actualBahmniObservation = bahmniObsService.getBahmniObservationByUuid(observationUuid, false);
+        BahmniObservation actualBahmniObservation = bahmniObsService.getBahmniObservationByUuid(observationUuid);
 
         verify(obsService, times(1)).getObsByUuid(observationUuid);
         verify(omrsObsToBahmniObsMapper, times(1)).map(obs);

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/BahmniObservationsController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/BahmniObservationsController.java
@@ -114,8 +114,12 @@ public class BahmniObservationsController extends BaseRestController {
 
     @RequestMapping(method = RequestMethod.GET, params = {"observationUuid"})
     @ResponseBody
-    public BahmniObservation get(@RequestParam(value = "observationUuid", required = true) String observationUuid) {
-        return bahmniObsService.getBahmniObservationByUuid(observationUuid, true);
+    public BahmniObservation get(@RequestParam(value = "observationUuid") String observationUuid,
+                                 @RequestParam(value = "revision", required = false) String revision) {
+        if (ObjectUtils.equals(revision, LATEST)) {
+            return bahmniObsService.getRevisedBahmniObservationByUuid(observationUuid);
+        }
+        return bahmniObsService.getBahmniObservationByUuid(observationUuid);
     }
 
     private void sendObsToGroovyScript(List<String> questions, Collection<BahmniObservation> observations) throws ParseException {

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniObservationsControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniObservationsControllerTest.java
@@ -131,7 +131,7 @@ public class BahmniObservationsControllerTest {
         String patientProgramUuid = null;
         when(bahmniExtensions.getExtension("observationsAdder","CurrentMonthOfTreatment.groovy")).thenReturn(null);
 
-        bahmniObservationsController.get(patientProgramUuid);
+        bahmniObservationsController.get(patientProgramUuid, null, null);
 
         verify(bahmniObsService, times(0)).getObservationsForPatientProgram(patientProgramUuid, conceptNames);
     }
@@ -163,11 +163,11 @@ public class BahmniObservationsControllerTest {
     public void shouldGetBahmniObservationWithTheGivenObservationUuid() throws Exception {
         String observationUuid = "observationUuid";
         BahmniObservation expectedBahmniObservation = new BahmniObservation();
-        when(bahmniObsService.getBahmniObservationByUuid(observationUuid, true)).thenReturn(expectedBahmniObservation);
+        when(bahmniObsService.getBahmniObservationByUuid(observationUuid)).thenReturn(expectedBahmniObservation);
 
-        BahmniObservation actualBahmniObservation = bahmniObservationsController.get(observationUuid);
+        BahmniObservation actualBahmniObservation = bahmniObservationsController.get(observationUuid, "");
 
-        verify(bahmniObsService, times(1)).getBahmniObservationByUuid("observationUuid", true);
+        verify(bahmniObsService, times(1)).getBahmniObservationByUuid("observationUuid");
         assertNotNull("BahmniObservation should not be null", actualBahmniObservation);
         assertEquals(expectedBahmniObservation, actualBahmniObservation);
     }


### PR DESCRIPTION
After OpenMRS 2.x upgrade the logic of Obs save changed. i.e when there is a change on obsTree at root level then entire tree will be replicated creating new Obs i.e the old obs uuid used to load the editobs page i.e 'patient.dashboard.observation' angular state is no more valid and the page throws exception.
To fix that we need to retrieve the revised obs when the obs is voided for replication.
This commit is to enhance the Bahmni Observation controller observation endpoint with ability to return revised obs when revision=latest is requested or else default.