### PR TITLE
BAH-406: Prevent double creation of sellable events 

### DIFF
--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/DepartmentEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/DepartmentEvent.java
@@ -4,6 +4,7 @@ import org.openmrs.Concept;
 
 import static org.bahmni.module.referencedata.labconcepts.contract.Department.DEPARTMENT_CONCEPT_CLASS;
 import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfConceptClass;
+import static org.bahmni.module.referencedata.labconcepts.model.event.SellableTypeEvent.isConceptWithSellableAttribute;
 
 public class DepartmentEvent extends ConceptOperationEvent {
 
@@ -13,7 +14,7 @@ public class DepartmentEvent extends ConceptOperationEvent {
 
     @Override
     public boolean isResourceConcept(Concept concept) {
-        return isOfConceptClass(concept, DEPARTMENT_CONCEPT_CLASS);
+        return isOfConceptClass(concept, DEPARTMENT_CONCEPT_CLASS) && !isConceptWithSellableAttribute(concept);
     }
 
 }

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/DrugEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/DrugEvent.java
@@ -2,6 +2,7 @@ package org.bahmni.module.referencedata.labconcepts.model.event;
 
 import org.ict4h.atomfeed.server.service.Event;
 import org.joda.time.DateTime;
+import org.openmrs.Concept;
 import org.openmrs.Drug;
 
 import java.net.URISyntaxException;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static java.util.Arrays.asList;
+import static org.bahmni.module.referencedata.labconcepts.model.event.SellableTypeEvent.isConceptWithSellableAttribute;
 
 public class DrugEvent implements ConceptServiceOperationEvent {
     protected String url;
@@ -35,7 +37,7 @@ public class DrugEvent implements ConceptServiceOperationEvent {
 
     @Override
     public Boolean isApplicable(String operation, Object[] arguments) {
-        return this.operations().contains(operation) && isValid(arguments) && arguments[0] instanceof Drug;
+        return this.operations().contains(operation) && isValid(arguments) && arguments[0] instanceof Drug && !isConceptWithSellableAttribute(((Drug) arguments[0]).getConcept());
     }
 
     @Override

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/LabTestEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/LabTestEvent.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 
 import static org.bahmni.module.referencedata.labconcepts.contract.LabTest.LAB_TEST_CONCEPT_CLASS;
 import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfConceptClass;
+import static org.bahmni.module.referencedata.labconcepts.model.event.SellableTypeEvent.isConceptWithSellableAttribute;
+
 
 public class LabTestEvent extends ConceptOperationEvent {
 
@@ -20,7 +22,7 @@ public class LabTestEvent extends ConceptOperationEvent {
     }
 
     public boolean isResourceConcept(Concept concept) {
-        return isOfConceptClass(concept, LAB_TEST_CONCEPT_CLASS) || (getParentOfTypeLabTest(concept) != null);
+        return (isOfConceptClass(concept, LAB_TEST_CONCEPT_CLASS) || (getParentOfTypeLabTest(concept) != null)) && !isConceptWithSellableAttribute(concept);
     }
 
     private Concept getParentOfTypeLabTest(Concept concept) {

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/PanelEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/PanelEvent.java
@@ -4,6 +4,7 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptClass;
 
 import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfConceptClassByUUID;
+import static org.bahmni.module.referencedata.labconcepts.model.event.SellableTypeEvent.isConceptWithSellableAttribute;
 
 public class PanelEvent extends ConceptOperationEvent {
 
@@ -13,7 +14,7 @@ public class PanelEvent extends ConceptOperationEvent {
 
     @Override
     public boolean isResourceConcept(Concept concept) {
-        return isOfConceptClassByUUID(concept, ConceptClass.LABSET_UUID);
+        return isOfConceptClassByUUID(concept, ConceptClass.LABSET_UUID) && !isConceptWithSellableAttribute(concept);
     }
 
 }

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/RadiologyTestEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/RadiologyTestEvent.java
@@ -4,6 +4,7 @@ import org.openmrs.Concept;
 
 import static org.bahmni.module.referencedata.labconcepts.contract.RadiologyTest.RADIOLOGY_TEST_CONCEPT_CLASS;
 import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfConceptClass;
+import static org.bahmni.module.referencedata.labconcepts.model.event.SellableTypeEvent.isConceptWithSellableAttribute;
 
 public class RadiologyTestEvent extends ConceptOperationEvent {
 
@@ -14,7 +15,7 @@ public class RadiologyTestEvent extends ConceptOperationEvent {
 
     @Override
     public boolean isResourceConcept(Concept concept) {
-        return isOfConceptClass(concept, RADIOLOGY_TEST_CONCEPT_CLASS);
+        return isOfConceptClass(concept, RADIOLOGY_TEST_CONCEPT_CLASS) && !isConceptWithSellableAttribute(concept);
     }
 
 

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SellableTypeEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SellableTypeEvent.java
@@ -38,9 +38,13 @@ public class SellableTypeEvent implements ConceptServiceOperationEvent {
         if (supportedOperations.contains(operation)
                 && arguments.length > 0 && arguments[0] instanceof Concept) {
             Concept concept = (Concept) arguments[0];
-            Collection<ConceptAttribute> activeAttributes = concept.getActiveAttributes();
-            return activeAttributes.stream().filter(a -> a.getAttributeType().getName().equalsIgnoreCase(SELLABLE_ATTR_NAME)).findFirst().isPresent();
+            return isConceptWithSellableAttribute(concept);
         }
         return false;
+    }
+
+    public static boolean isConceptWithSellableAttribute(Concept concept) {
+        Collection<ConceptAttribute> activeAttributes = concept.getActiveAttributes();
+        return activeAttributes.stream().filter(a -> a.getAttributeType().getName().equalsIgnoreCase(SELLABLE_ATTR_NAME)).findFirst().isPresent();
     }
 }


### PR DESCRIPTION
Prevent double creation of sellable events if they're also registered in other watched categories.

As shown here https://github.com/Bahmni/bahmni-core/blob/master/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/Operation.java#L25-L33

We already had watched types and type sellable is meant to be generic. So if for example a radiology order is saved for a concept that also has sellable attribute, this order will be created twice. Once by RadiologyTestEvent and again by SellableTypeEvent.

