### PR TITLE
Move setting of properties to ResourceMapper

### DIFF
--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AllTestsAndPanelsMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AllTestsAndPanelsMapper.java
@@ -11,7 +11,7 @@ public class AllTestsAndPanelsMapper extends ResourceMapper {
     @Override
     public AllTestsAndPanels map(Concept testsAndPanelsConcept) {
         AllTestsAndPanels allTestsAndPanels = new AllTestsAndPanels();
-        allTestsAndPanels = mapResource(allTestsAndPanels, testsAndPanelsConcept);
+        allTestsAndPanels = mapResource(allTestsAndPanels, testsAndPanelsConcept, true);
         allTestsAndPanels.setDescription(ConceptExtension.getDescription(testsAndPanelsConcept));
         allTestsAndPanels.setTestsAndPanels(new TestAndPanelMapper().map(testsAndPanelsConcept));
         return allTestsAndPanels;

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AttributableResourceMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AttributableResourceMapper.java
@@ -3,8 +3,6 @@ package org.bahmni.module.referencedata.labconcepts.mapper;
 import org.openmrs.Concept;
 import org.bahmni.module.referencedata.labconcepts.contract.Resource;
 
-import java.util.HashMap;
-
 public class AttributableResourceMapper extends ResourceMapper {
 
     public AttributableResourceMapper() {super(null);}
@@ -17,11 +15,6 @@ public class AttributableResourceMapper extends ResourceMapper {
     public Resource map(Concept concept) {
         Resource resource = new Resource();
         mapResource(resource, concept);
-        HashMap<String, Object> properties = new HashMap<>();
-        concept.getActiveAttributes().stream().forEach(a -> properties.put(a.getAttributeType().getName(), a.getValueReference()));
-        if (!properties.isEmpty()) {
-            resource.setProperties(properties);
-        }
         return resource;
     }
 }

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AttributableResourceMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AttributableResourceMapper.java
@@ -14,7 +14,7 @@ public class AttributableResourceMapper extends ResourceMapper {
     @Override
     public Resource map(Concept concept) {
         Resource resource = new Resource();
-        mapResource(resource, concept);
+        mapResource(resource, concept, true);
         return resource;
     }
 }

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/LabTestMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/LabTestMapper.java
@@ -12,7 +12,7 @@ public class LabTestMapper extends ResourceMapper {
     @Override
     public LabTest map(Concept testConcept) {
         LabTest test = new LabTest();
-        test = mapResource(test, testConcept);
+        test = mapResource(test, testConcept, true);
         test.setDescription(ConceptExtension.getDescriptionOrName(testConcept));
         test.setResultType(testConcept.getDatatype().getName());
         test.setTestUnitOfMeasure(ConceptExtension.getUnits(testConcept));

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/RadiologyTestMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/RadiologyTestMapper.java
@@ -10,7 +10,7 @@ public class RadiologyTestMapper extends ResourceMapper {
 
     @Override
     public RadiologyTest map(Concept testConcept) {
-        return mapResource(new RadiologyTest(), testConcept);
+        return mapResource(new RadiologyTest(), testConcept, true);
     }
 
 

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
@@ -5,6 +5,7 @@ import org.openmrs.Concept;
 import org.openmrs.ConceptSet;
 import org.openmrs.api.context.Context;
 
+import java.util.HashMap;
 import java.util.List;
 
 public abstract class ResourceMapper {
@@ -24,6 +25,11 @@ public abstract class ResourceMapper {
         resource.setId(concept.getUuid());
         resource.setDateCreated(concept.getDateCreated());
         resource.setLastUpdated(concept.getDateChanged());
+        HashMap<String, Object> properties = new HashMap<>();
+        concept.getActiveAttributes().stream().forEach(a -> properties.put(a.getAttributeType().getName(), a.getValueReference()));
+        if (!properties.isEmpty()) {
+            resource.setProperties(properties);
+        }
         return (R) resource;
     }
 

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
@@ -26,12 +26,19 @@ public abstract class ResourceMapper {
         resource.setId(concept.getUuid());
         resource.setDateCreated(concept.getDateCreated());
         resource.setLastUpdated(concept.getDateChanged());
-        HashMap<String, Object> properties = new HashMap<>();
-        concept.getActiveAttributes().stream().forEach(a -> properties.put(a.getAttributeType().getName(), a.getValueReference()));
-        if (!MapUtils.isEmpty(properties)) {
-            resource.setProperties(properties);
-        }
         return (R) resource;
+    }
+
+    public <R extends Resource> R mapResource(R resource, Concept concept, boolean shouldSetProperties) {
+        mapResource(resource, concept);
+        if (shouldSetProperties) {
+            HashMap<String, Object> properties = new HashMap<>();
+            concept.getActiveAttributes().stream().forEach(a -> properties.put(a.getAttributeType().getName(), a.getValueReference()));
+            if (!MapUtils.isEmpty(properties)) {
+                resource.setProperties(properties);
+            }
+        }
+        return resource;
     }
 
     Double getSortWeight(Concept concept) {

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/ResourceMapper.java
@@ -1,5 +1,6 @@
 package org.bahmni.module.referencedata.labconcepts.mapper;
 
+import org.apache.commons.collections.MapUtils;
 import org.bahmni.module.referencedata.labconcepts.contract.Resource;
 import org.openmrs.Concept;
 import org.openmrs.ConceptSet;
@@ -27,7 +28,7 @@ public abstract class ResourceMapper {
         resource.setLastUpdated(concept.getDateChanged());
         HashMap<String, Object> properties = new HashMap<>();
         concept.getActiveAttributes().stream().forEach(a -> properties.put(a.getAttributeType().getName(), a.getValueReference()));
-        if (!properties.isEmpty()) {
+        if (!MapUtils.isEmpty(properties)) {
             resource.setProperties(properties);
         }
         return (R) resource;


### PR DESCRIPTION
BAH-406: Make other resources behave similar to a sellable resource. That is should be set to inactive when sellable is false.

This change is necessary for openerp-atomfeed-service to have access to the sellable property in the resource json.