### PR TITLE
BAH-837 | Update modules version to 0.93-SNAPSHOT

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin</artifactId>
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>bahmni-migrator</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>bahmni-emr-api</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>

--- a/bahmni-emr-api/pom.xml
+++ b/bahmni-emr-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bahmni-mapping/pom.xml
+++ b/bahmni-mapping/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>bahmni-mapping</artifactId>
     <packaging>jar</packaging>

--- a/bahmni-test-commons/pom.xml
+++ b/bahmni-test-commons/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bahmnicore-api/pom.xml
+++ b/bahmnicore-api/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-api</artifactId>
     <packaging>jar</packaging>
-    <name>BahmniEMR Core API</name>
+    <name>Bahmni EMR Core API</name>
 
     <dependencies>
         <dependency>
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>web-clients</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>

--- a/bahmnicore-omod/pom.xml
+++ b/bahmnicore-omod/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-omod</artifactId>
     <packaging>jar</packaging>
-    <name>BahmniEMR Core OMOD</name>
+    <name>Bahmni EMR Core OMOD</name>
 
     <properties>
         <MODULE_ID>bahmnicore</MODULE_ID>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>mail-appender</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>
@@ -104,12 +104,12 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>common</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>file-uploader</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.bahmni.module</groupId>
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>org.bahmni.test</groupId>
             <artifactId>bahmni-test-commons</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -286,13 +286,13 @@
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>rulesengine-api</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${rulesEngineVersion}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>rulesengine-api</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${rulesEngineVersion}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bahmnicore-omod/src/main/resources/config.xml
+++ b/bahmnicore-omod/src/main/resources/config.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE module PUBLIC "-//OpenMRS//DTD OpenMRS Config 1.0//EN" "http://resources.openmrs.org/doctype/config-1.2.dtd">
 
 <module configVersion="1.2">
-	
+
     <!-- Base Module Properties -->
     <id>@MODULE_ID@</id>
     <name>@MODULE_NAME@</name>
@@ -10,13 +10,13 @@
     <package>@MODULE_PACKAGE@</package>
     <author>Bahmni</author>
     <description>
-        Provides core BahmniEMR services
+        Provides core Bahmni EMR services
     </description>
     <activator>@MODULE_PACKAGE@.Activator</activator>
 
     <updateURL>https://example.com/modules/download/bahmnicore/update.rdf</updateURL>
     <!-- /Base Module Properties -->
-	
+
     <require_version>${openMRSRuntimeVersion}</require_version>
     <require_modules>
         <require_module>org.openmrs.module.webservices.rest</require_module>
@@ -34,10 +34,10 @@
         <require_module>org.openmrs.module.auditlog</require_module>
     </require_modules>
     <!-- Extensions -->
-	
+
     <!-- AOP -->
     <!-- Required Privileges -->
-    
+
     <privilege>
         <name>Add Patient Lists</name>
         <description>Ability to create patient lists</description>
@@ -54,7 +54,7 @@
         <name>View Patient Lists</name>
         <description>Ability to view patient lists</description>
     </privilege>
-    
+
     <privilege>
         <name>Add Drug Groups</name>
         <description>Ability to create Drug Groups</description>
@@ -70,8 +70,8 @@
     <privilege>
         <name>View Drug Groups</name>
         <description>Ability to view Drug Groups</description>
-    </privilege>   
-    
+    </privilege>
+
     <privilege>
         <name>Add Drug Info</name>
         <description>Ability to create Drug Info</description>

--- a/bahmnicore-ui/pom.xml
+++ b/bahmnicore-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-ui</artifactId>
     <packaging>jar</packaging>
@@ -189,4 +189,3 @@
     </build>
 
 </project>
-

--- a/jss-old-data/pom.xml
+++ b/jss-old-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,12 +14,12 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>bahmni-migrator</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>openmrs-connector</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/obs-relation/pom.xml
+++ b/obs-relation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>obs-relationship</artifactId>
     <packaging>jar</packaging>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.bahmni.test</groupId>
             <artifactId>bahmni-test-commons</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/openmrs-elis-atomfeed-client-omod/pom.xml
+++ b/openmrs-elis-atomfeed-client-omod/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>openelis-atomfeed-client-omod</artifactId>
     <packaging>jar</packaging>
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>web-clients</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${bahmniJavaUtilsVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>bahmni</artifactId>
     <version>0.93-SNAPSHOT</version>
     <packaging>pom</packaging>
-    <name>BahmniEMR Core</name>
+    <name>Bahmni EMR Core</name>
 
     <modules>
         <module>bahmni-emr-api</module>
@@ -40,16 +40,20 @@
         <legacyuiVersion>1.3.3</legacyuiVersion>
         <episodes.version>1.0-SNAPSHOT</episodes.version>
         <auditLogVersion>1.0-SNAPSHOT</auditLogVersion>
+        <bacteriology.version>1.1-SNAPSHOT</bacteriology.version>
+        <rulesEngineVersion>0.92-SNAPSHOT</rulesEngineVersion>
+        <bahmniJavaUtilsVersion>0.92-SNAPSHOT</bahmniJavaUtilsVersion>
+
         <!--test dependencies-->
+
         <junitVersion>4.12</junitVersion>
         <powerMockVersion>1.6.5</powerMockVersion>
         <hamcrestVersion>1.3</hamcrestVersion>
         <mockitoVersion>1.10.19</mockitoVersion>
         <argLine>-Xmx1024m</argLine>
-        <bacteriology.version>1.1-SNAPSHOT</bacteriology.version>
     </properties>
 
-   
+
 <distributionManagement>
        <snapshotRepository>
            <id>repo.mybahmni.org</id>
@@ -180,7 +184,7 @@
             <dependency>
                 <groupId>org.bahmni.module</groupId>
                 <artifactId>bahmni-migrator</artifactId>
-                <version>0.92-SNAPSHOT</version>
+                <version>${bahmniJavaUtilsVersion}</version>
                 <type>jar</type>
                 <scope>provided</scope>
             </dependency>
@@ -291,7 +295,7 @@
             <dependency>
                 <groupId>org.bahmni.module</groupId>
                 <artifactId>file-uploader</artifactId>
-                <version>${project.parent.version}</version>
+                <version>${bahmniJavaUtilsVersion}</version>
             </dependency>
             <dependency>
                 <groupId>org.openmrs.module</groupId>
@@ -387,7 +391,7 @@
 
 
     </dependencyManagement>
-    
+
     <dependencies>
         <dependency>
             <groupId>log4j</groupId>
@@ -590,7 +594,7 @@
           <id>repo.mybahmni.org-release</id>
           <name>bahmni-artifactory-release</name>
           <url>http://repo.mybahmni.org.s3.amazonaws.com/artifactory/release</url>
-      </repository>      
+      </repository>
         <repository>
             <id>rubygems-releases</id>
             <url>http://rubygems-proxy.torquebox.org/releases</url>

--- a/reference-data/api/pom.xml
+++ b/reference-data/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reference-data/omod/pom.xml
+++ b/reference-data/omod/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.bahmni.test</groupId>
             <artifactId>bahmni-test-commons</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/reference-data/pom.xml
+++ b/reference-data/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
     <artifactId>reference-data</artifactId>
     <packaging>pom</packaging>

--- a/vagrant-deploy/pom.xml
+++ b/vagrant-deploy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>0.92-SNAPSHOT</version>
+        <version>0.93-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>reference-data-omod</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Update all sub project (module) versions to 0.93-SNAPSHOT as well. Only the main pom.xml was updated.
- Refactor the module version to clearly distinguish Bahmni Core deps from Bahmni Java Utils deps using Maven variables.
- Use Maven vars to avoid having to manually type the depending versions.