### PR TITLE
BAH-851 | downgrading web-clients dependency for bahmni-core:release-0.92

### DIFF
--- a/bahmnicore-api/pom.xml
+++ b/bahmnicore-api/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>web-clients</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>0.91-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>

--- a/openmrs-elis-atomfeed-client-omod/pom.xml
+++ b/openmrs-elis-atomfeed-client-omod/pom.xml
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>org.bahmni.module</groupId>
             <artifactId>web-clients</artifactId>
-            <version>0.92-SNAPSHOT</version>
+            <version>0.91-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>


### PR DESCRIPTION
BAH-851 | downgrading web-clients dependency for bahmni-core:release-0.92. provided httpclient library version is 4.2 by idgen