### PR TITLE
Rakesh, Siva | BAH-1157 | Global Property CSV Date format support

### DIFF
--- a/admin/src/main/java/org/bahmni/module/admin/csv/service/CSVPatientService.java
+++ b/admin/src/main/java/org/bahmni/module/admin/csv/service/CSVPatientService.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
+import static org.bahmni.module.admin.csv.utils.CSVUtils.getDateStringInSupportedFormat;
 import static org.bahmni.module.admin.csv.utils.CSVUtils.getDateFromString;
 
 public class CSVPatientService {
@@ -92,10 +93,12 @@ public class CSVPatientService {
     		} else if (personAttributeType.getFormat().startsWith("java.lang.")) {
     		    patient.addAttribute(new PersonAttribute(findAttributeType(attribute.getKey()), attribute.getValue()));
     		} else if (personAttributeType.getFormat().startsWith("org.openmrs.util.AttributableDate")) {
-    		    //Validating the Date format
+
     		    String dateString = attribute.getValue();
-    		    getDateFromString(dateString);
-    		    patient.addAttribute(new PersonAttribute(findAttributeType(attribute.getKey()),dateString));
+                //Validating the Date format
+                getDateFromString(dateString);
+                String supportedDateString = getDateStringInSupportedFormat(dateString);
+    		    patient.addAttribute(new PersonAttribute(findAttributeType(attribute.getKey()),supportedDateString));
     		}
     	}
     }

--- a/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
+++ b/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
@@ -1,6 +1,7 @@
 package org.bahmni.module.admin.csv.utils;
 
 import org.bahmni.csv.KeyValue;
+import org.openmrs.api.context.Context;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -12,6 +13,10 @@ import java.util.List;
 public class CSVUtils {
 
     public static final String ENCOUNTER_DATE_PATTERN = "yyyy-M-d";
+    public static String getCsvGlobalDateFormat(){
+       return "yyyy-M-d";
+       // return Context.getAdministrationService().getGlobalProperty("bahmni.admin.csv.upload.dateFormat");
+    };
 
     public static String[] getStringArray(List<KeyValue> keyValueList) {
         List<String> stringList = new ArrayList<>();
@@ -29,9 +34,22 @@ public class CSVUtils {
         return keyValueList;
     }
 
+//    public static Date getDateFromString(String dateString) throws ParseException {
+//        // All csv imports use the same date format
+//        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
+//        simpleDateFormat.setLenient(false);
+//        return simpleDateFormat.parse(dateString);
+//    }
+
     public static Date getDateFromString(String dateString) throws ParseException {
-        // All csv imports use the same date format
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
+        // All csv imports use the date format from global properties
+        SimpleDateFormat simpleDateFormat;
+        String dateGlobalProperty = getCsvGlobalDateFormat();
+        if( dateGlobalProperty != null) {
+            simpleDateFormat = new SimpleDateFormat(dateGlobalProperty);
+        }else{
+            simpleDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
+        }
         simpleDateFormat.setLenient(false);
         return simpleDateFormat.parse(dateString);
     }

--- a/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
+++ b/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
@@ -1,6 +1,7 @@
 package org.bahmni.module.admin.csv.utils;
 
 import org.bahmni.csv.KeyValue;
+import org.bahmni.csv.exception.MigrationException;
 import org.openmrs.api.context.Context;
 
 import java.text.DateFormat;
@@ -35,18 +36,38 @@ public class CSVUtils {
         return keyValueList;
     }
 
+    public static String getDateStringInSupportedFormat(String dateString) throws ParseException {
+        String dateGlobalProperty = getCsvGlobalDateFormat();
+        SimpleDateFormat simpleDateFormat;
+        if( dateGlobalProperty != null) {
+            simpleDateFormat = new SimpleDateFormat(dateGlobalProperty);
+            simpleDateFormat.setLenient(false);
+            Date date = new Date(simpleDateFormat.parse(dateString).getTime());
+
+            SimpleDateFormat defaultDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
+            return defaultDateFormat.format(date);
+        }else{
+            return dateString;
+        }
+    };
+
     public static Date getDateFromString(String dateString) throws ParseException {
         // All csv imports use the date format from global properties
         SimpleDateFormat simpleDateFormat;
         String dateGlobalProperty = getCsvGlobalDateFormat();
-        if( dateGlobalProperty != null) {
-            simpleDateFormat = new SimpleDateFormat(dateGlobalProperty);
-        }else{
+        String expectedDateFormat = dateGlobalProperty != null ? dateGlobalProperty : ENCOUNTER_DATE_PATTERN;
+        try {
+            if (dateGlobalProperty != null) {
+                dateString = getDateStringInSupportedFormat(dateString);
+            }
             simpleDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
+            simpleDateFormat.setLenient(false);
+            return simpleDateFormat.parse(dateString);
         }
-        simpleDateFormat.setLenient(false);
-        return simpleDateFormat.parse(dateString);
-    }
+        catch (ParseException e){
+            throw new MigrationException("Date format " + dateString + " doesn't match `bahmni.admin.csv.upload.dateFormat` global property, expected format " + expectedDateFormat );
+        }
+    };
 
     public static Date getTodayDate() throws ParseException {
         DateFormat dateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);

--- a/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
+++ b/admin/src/main/java/org/bahmni/module/admin/csv/utils/CSVUtils.java
@@ -13,9 +13,10 @@ import java.util.List;
 public class CSVUtils {
 
     public static final String ENCOUNTER_DATE_PATTERN = "yyyy-M-d";
+    private final static String GLOBAL_DATE_FORMAT = "bahmni.admin.csv.upload.dateFormat";
+
     public static String getCsvGlobalDateFormat(){
-       return "yyyy-M-d";
-       // return Context.getAdministrationService().getGlobalProperty("bahmni.admin.csv.upload.dateFormat");
+        return Context.getAdministrationService().getGlobalProperty(GLOBAL_DATE_FORMAT);
     };
 
     public static String[] getStringArray(List<KeyValue> keyValueList) {
@@ -33,13 +34,6 @@ public class CSVUtils {
         }
         return keyValueList;
     }
-
-//    public static Date getDateFromString(String dateString) throws ParseException {
-//        // All csv imports use the same date format
-//        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(ENCOUNTER_DATE_PATTERN);
-//        simpleDateFormat.setLenient(false);
-//        return simpleDateFormat.parse(dateString);
-//    }
 
     public static Date getDateFromString(String dateString) throws ParseException {
         // All csv imports use the date format from global properties

--- a/admin/src/main/java/org/bahmni/module/admin/observation/CSVObservationHelper.java
+++ b/admin/src/main/java/org/bahmni/module/admin/observation/CSVObservationHelper.java
@@ -31,6 +31,7 @@ import static java.util.Arrays.asList;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.springframework.util.CollectionUtils.isEmpty;
+import static org.bahmni.module.admin.csv.utils.CSVUtils.getDateStringInSupportedFormat;
 
 @Component
 public class CSVObservationHelper {
@@ -120,7 +121,7 @@ public class CSVObservationHelper {
         return existingObservation;
     }
 
-    private Observation createObservation(List<String> conceptNames, Date encounterDate, KeyValue obsRow) {
+    private Observation createObservation(List<String> conceptNames, Date encounterDate, KeyValue obsRow) throws ParseException {
         Concept obsConcept = conceptCache.getConcept(conceptNames.get(0));
         EncounterTransaction.Concept concept = new EncounterTransaction.Concept(obsConcept.getUuid(),
                 obsConcept.getName().getName());
@@ -150,10 +151,14 @@ public class CSVObservationHelper {
         if (nonNull(recordedObsValue) && ((nonNull(hiNormal) && recordedObsValue.compareTo(hiNormal) > 0) || (nonNull(lowNormal) && recordedObsValue.compareTo(lowNormal) < 0))) {
             observation.setInterpretation(String.valueOf(Obs.Interpretation.ABNORMAL));
         }
-    }
+    };
 
-    private Object getValue(KeyValue obsRow, Concept obsConcept) {
+    private Object getValue(KeyValue obsRow, Concept obsConcept) throws ParseException {
         Map<String, Object> valueConcept = null;
+        if(obsConcept.getDatatype().isDate()) {
+            String dateString = obsRow.getValue();
+            return getDateStringInSupportedFormat(dateString);
+        }
         if (obsConcept.getDatatype().isCoded()) {
             List<Concept> valueConcepts = conceptService.getConceptsByName(obsRow.getValue());
             for (Concept concept : valueConcepts) {

--- a/admin/src/test/java/org/bahmni/module/admin/csv/persister/RelationshipPersisterTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/csv/persister/RelationshipPersisterTest.java
@@ -75,14 +75,14 @@ public class RelationshipPersisterTest {
     @Test
     public void shouldThrowExceptionIfTheStartDateFormatIsWrong() throws Exception {
         expectedEx.expect(RuntimeException.class);
-        expectedEx.expectMessage("Could not parse provided dates. Please provide date in format yyyy-mm-dd");
+        expectedEx.expectMessage("Date format 02-01-2015 doesn't match `bahmni.admin.csv.upload.dateFormat` global property, expected format yyyy-M-d");
         getRelationshipPersister().validateRow(new RelationshipRow("GAN200012", "GAN200015", "ProviderName", "Child", "02-01-2015", "2014-01-01"));
     }
 
     @Test
     public void shouldThrowExceptionIfTheEndDateFormatIsWrong() throws Exception {
         expectedEx.expect(RuntimeException.class);
-        expectedEx.expectMessage("Could not parse provided dates. Please provide date in format yyyy-mm-dd");
+        expectedEx.expectMessage("Date format 01-01-2014 doesn't match `bahmni.admin.csv.upload.dateFormat` global property, expected format yyyy-M-d");
         getRelationshipPersister().validateRow(new RelationshipRow("GAN200012", "GAN200015", "ProviderName", "Child", "2015-02-01", "01-01-2014"));
     }
 

--- a/admin/src/test/java/org/bahmni/module/admin/csv/persister/RelationshipPersisterTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/csv/persister/RelationshipPersisterTest.java
@@ -2,16 +2,40 @@ package org.bahmni.module.admin.csv.persister;
 
 import org.bahmni.csv.Messages;
 import org.bahmni.module.admin.csv.models.RelationshipRow;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
 public class RelationshipPersisterTest {
+
+    @Mock
+    private AdministrationService administrationService;
 
     @Rule
     public ExpectedException expectedEx = ExpectedException.none();
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(administrationService);
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
+    }
 
     @Test
     public void shouldPassValidationIfAllRequiredFieldsAreProvided() throws Exception {

--- a/admin/src/test/java/org/bahmni/module/admin/csv/service/CSVPatientServiceTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/csv/service/CSVPatientServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.openmrs.Concept;
@@ -20,9 +21,13 @@ import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.addresshierarchy.AddressField;
 import org.openmrs.module.addresshierarchy.AddressHierarchyLevel;
 import org.openmrs.module.addresshierarchy.service.AddressHierarchyService;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -33,6 +38,9 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.eq;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isNull;
@@ -40,6 +48,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
 public class CSVPatientServiceTest {
 
     @Rule
@@ -62,6 +72,9 @@ public class CSVPatientServiceTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(mockAdminService);
+        when(mockAdminService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
     }
 
     @Test

--- a/admin/src/test/java/org/bahmni/module/admin/csv/service/CSVRelationshipServiceTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/csv/service/CSVRelationshipServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
@@ -14,6 +15,10 @@ import org.openmrs.RelationshipType;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.ArrayList;
@@ -21,11 +26,12 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
 public class CSVRelationshipServiceTest {
     @Mock
     private BahmniPatientService patientService;
@@ -48,6 +54,9 @@ public class CSVRelationshipServiceTest {
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(administrationService);
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
         csvRelationshipService = new CSVRelationshipService(patientService, personService, providerService, administrationService);
     }
 
@@ -137,6 +146,8 @@ public class CSVRelationshipServiceTest {
         when(patientService.getByAIsToB("Doctor")).thenReturn(relationshipTypes);
         when(providerService.getProviders("Super User", null, null, null)).thenReturn(getProviders());
         when(administrationService.getGlobalProperty(anyString())).thenReturn("{provider: [\"Doctor\"]}");
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
+
         Relationship expectedRelationship = new Relationship();
         expectedRelationship.setPersonA(getPatients().get(0));
         expectedRelationship.setPersonB(getProviders().get(0).getPerson());

--- a/admin/src/test/java/org/bahmni/module/admin/observation/DiagnosisMapperTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/observation/DiagnosisMapperTest.java
@@ -2,9 +2,17 @@ package org.bahmni.module.admin.observation;
 
 import org.bahmni.csv.KeyValue;
 import org.bahmni.module.admin.csv.models.EncounterRow;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.diagnosis.contract.BahmniDiagnosisRequest;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.util.Assert;
 
 import java.text.ParseException;
@@ -12,10 +20,25 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
 public class DiagnosisMapperTest {
+
+    @Mock
+    private AdministrationService administrationService;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(administrationService);
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
+    }
     @Test
     public void ignoreEmptyDiagnosis() throws ParseException {
         List<KeyValue> diagnosesKeyValues = Arrays.asList(new KeyValue("diagnosis", " "));

--- a/admin/src/test/java/org/bahmni/module/admin/observation/handler/Form1CSVObsHandlerTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/observation/handler/Form1CSVObsHandlerTest.java
@@ -6,7 +6,14 @@ import org.bahmni.module.admin.csv.models.EncounterRow;
 import org.bahmni.module.admin.observation.CSVObservationHelper;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.text.ParseException;
 import java.util.Date;
@@ -14,24 +21,31 @@ import java.util.List;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class})
 public class Form1CSVObsHandlerTest {
 
     private Form1CSVObsHandler form1CSVObsHandler;
 
     private CSVObservationHelper csvObservationHelper;
 
+    @Mock
+    private AdministrationService administrationService;
+
     @Before
     public void setUp() {
         initMocks(this);
         csvObservationHelper = mock(CSVObservationHelper.class);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(administrationService);
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
     }
 
     @Test

--- a/admin/src/test/java/org/bahmni/module/admin/observation/handler/Form2CSVObsHandlerTest.java
+++ b/admin/src/test/java/org/bahmni/module/admin/observation/handler/Form2CSVObsHandlerTest.java
@@ -10,7 +10,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.openmrs.api.APIException;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -27,11 +30,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@PrepareForTest(CSVObservationHelper.class)
+@PrepareForTest({CSVObservationHelper.class, Context.class})
 @RunWith(PowerMockRunner.class)
 public class Form2CSVObsHandlerTest {
 
@@ -42,12 +46,18 @@ public class Form2CSVObsHandlerTest {
     private FormFieldPathService formFieldPathService;
     private FormFieldPathGeneratorService formFieldPathGeneratorService;
 
+    @Mock
+    private AdministrationService administrationService;
+
     @Before
     public void setUp() {
         initMocks(this);
         csvObservationHelper = mock(CSVObservationHelper.class);
         formFieldPathService = mock(FormFieldPathService.class);
         formFieldPathGeneratorService = mock(FormFieldPathGeneratorService.class);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getAdministrationService()).thenReturn(administrationService);
+        when(administrationService.getGlobalProperty(eq("bahmni.admin.csv.upload.dateFormat"))).thenReturn("yyyy-M-d");
     }
 
     @Test

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4523,4 +4523,16 @@
     		INSERT INTO role_privilege (role, privilege) VALUES ('Anonymous', 'Get Locations');
     	</sql>
     </changeSet>
+    <changeSet id="bahmni-core-202102230936" author="Siva, Rakesh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property where property = 'bahmni.admin.csv.upload.dateFormat'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add default date format for all CSV imports</comment>
+        <sql>
+            insert into global_property (`property`, `property_value`, `description`, `uuid`)
+            values ('bahmni.admin.csv.upload.dateFormat', 'yyyy-M-d', 'Default date format for all CSV imports', uuid());
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Description: 

Given that a user has date concepts in the CSV (for both registrations and forms), when the user has date format as YYYY/MM/DD (i.e. using slash as separator), then the data should be successfully be imported in the concept.

Note: At present migration only supports hyphen as a separator in the date format, i.e. YYYY-MM-DD.

Added support for global property bahmni.admin.csv.upload.dateFormat

User can set a valid date format in global property

CSV dates will be parsed using the set dateFormat.