### PR TITLE
fix bug: getAll missing observations

### DIFF
--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/laborder/service/LabOrderResultsServiceImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/laborder/service/LabOrderResultsServiceImpl.java
@@ -64,17 +64,18 @@ public class LabOrderResultsServiceImpl implements LabOrderResultsService {
         int currentAccession = 0;
         for (int count = totalEncounters - 1; count >= 0; count--) {
             Encounter encounter = encounters.get(count);
-
             EncounterTransaction encounterTransaction = encounterTransactionMapper.map(encounter, false);
-            List<EncounterTransaction.Order> existingTestOrders = filterTestOrders(encounterTransaction, encounter, encounterTestOrderUuidMap, null, null, null);
-            testOrders.addAll(existingTestOrders);
+            if (currentAccession < numberOfAccessions) {
+                List<EncounterTransaction.Order> existingTestOrders = filterTestOrders(encounterTransaction, encounter, encounterTestOrderUuidMap, null, null, null);
+                testOrders.addAll(existingTestOrders);
+                if (existingTestOrders.size() > 0) {
+                    currentAccession++;
+                }
+            }
             List<EncounterTransaction.Observation> nonVoidedObservations = filterObservations(encounterTransaction.getObservations(), null, null);
             observations.addAll(nonVoidedObservations);
             createAccessionNotesByEncounter(encounterToAccessionNotesMap, encounters, encounter);
-            mapObservationsWithEncounter(nonVoidedObservations, encounter, encounterObservationMap);
-            if (existingTestOrders.size() > 0) {
-                currentAccession++;
-            }
+            mapObservationsWithEncounter(nonVoidedObservations, encounter, encounterObservationMap);            
         }
 
         List<LabOrderResult> labOrderResults = mapOrdersWithObs(testOrders, observations, encounterTestOrderUuidMap, encounterObservationMap, encounterToAccessionNotesMap);

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/laborder/service/LabOrderResultsServiceImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/laborder/service/LabOrderResultsServiceImpl.java
@@ -64,9 +64,6 @@ public class LabOrderResultsServiceImpl implements LabOrderResultsService {
         int currentAccession = 0;
         for (int count = totalEncounters - 1; count >= 0; count--) {
             Encounter encounter = encounters.get(count);
-            if (currentAccession >= numberOfAccessions) {
-                break;
-            }
 
             EncounterTransaction encounterTransaction = encounterTransactionMapper.map(encounter, false);
             List<EncounterTransaction.Order> existingTestOrders = filterTestOrders(encounterTransaction, encounter, encounterTestOrderUuidMap, null, null, null);


### PR DESCRIPTION
The shortcut on lines 67-69 LabOrderResultsServiceImpl.java causes an unexcpected result where, when getAll has numberOfAccessions set, observations for orders will only be attached to orders if their encounter is before the last encounter reached by this loop. When using numberOfAccessions, this causes orders to be returned without their associated observed values. The solution seems to be to just remove the shortcut. I haven't tested this.