### PR TITLE
BAH-1888 | Test mechanism failure tests are fixed in ObsToObsTabularFlowSheetControllerTest.java for build success

### DIFF
--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/ObsToObsTabularFlowSheetControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/ObsToObsTabularFlowSheetControllerTest.java
@@ -146,31 +146,30 @@ public class ObsToObsTabularFlowSheetControllerTest {
     }
 
     @Test
-    @Ignore // Test mechanism failure
     public void shouldReturnEmptyPivotTableWhenFormNamesAreNotGiven() throws ParseException {
 
-        PivotTable pivotTable = obsToObsPivotTableController.constructPivotTableFor(any(), any(), any(), any(), any(),
-                singletonList(""), any(), any(), any(), any(), any(), any(), null);
-
+        ObsToObsTabularFlowSheetController obsToObsTabularFlowSheetController = spy(obsToObsPivotTableController);
+        PivotTable pivotTable = obsToObsTabularFlowSheetController.constructPivotTableFor(any(), any(), any(), any(), any(),
+                eq(singletonList("")), any(), any(), any(), any(), any(), any(), eq(null));
         assertEquals(0, pivotTable.getHeaders().size());
     }
 
     @Test
-    @Ignore // Test mechanism failure
     public void shouldReturnEmptyPivotTableWhenConceptNamesAreNotGiven() throws ParseException {
 
-        PivotTable pivotTable = obsToObsPivotTableController.constructPivotTableFor(any(), any(), any(), any(), any(),
-                null, any(), any(), any(), any(), any(), any(), singletonList(""));
+        ObsToObsTabularFlowSheetController obsToObsTabularFlowSheetController = spy(obsToObsPivotTableController);
+        PivotTable pivotTable = obsToObsTabularFlowSheetController.constructPivotTableFor(any(), any(), any(), any(), any(),
+                eq(null), any(), any(), any(), any(), any(), any(), eq(singletonList("")));
 
         assertEquals(0, pivotTable.getHeaders().size());
     }
 
     @Test
-    @Ignore // Test mechanism failure
     public void shouldReturnEmptyPivotTableWhenFormNamesAreEmpty() throws ParseException {
 
-        PivotTable pivotTable = obsToObsPivotTableController.constructPivotTableFor(any(), any(), any(), any(), any(),
-                null, any(), any(), any(), any(), any(), any(), emptyList());
+        ObsToObsTabularFlowSheetController obsToObsTabularFlowSheetController = spy(obsToObsPivotTableController);
+        PivotTable pivotTable = obsToObsTabularFlowSheetController.constructPivotTableFor(any(), any(), any(), any(), any(),
+                eq(null), any(), any(), any(), any(), any(), any(), eq(emptyList()));
 
         assertEquals(0, pivotTable.getHeaders().size());
     }


### PR DESCRIPTION

Passed raw data when comparing with argument matchers in eq(data) and mocked the controller instead of directly using it.

