### PR TITLE
BAH-2132 | Fix. Search by ID throws error without having address field in AddressSearchResultFields

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/patient/PatientSearchParameters.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/patient/PatientSearchParameters.java
@@ -56,7 +56,7 @@ public class PatientSearchParameters {
         }
         this.setAddressFieldValue(context.getParameter("addressFieldValue"));
         Map parameterMap = context.getRequest().getParameterMap();
-        this.setAddressSearchResultFields(!Arrays.toString((Object[]) parameterMap.get("addressSearchResultsConfig")).equals("[{}]") ? (String[]) parameterMap.get("addressSearchResultsConfig") : null);
+        this.setAddressSearchResultFields(getAddressConfigIfExists(parameterMap.get("addressSearchResultsConfig")));
         this.setPatientSearchResultFields((String[]) parameterMap.get("patientSearchResultsConfig"));
         this.setPatientAttributes((String[]) parameterMap.get("patientAttributes"));
         this.setProgramAttributeFieldValue(context.getParameter("programAttributeFieldValue"));
@@ -64,6 +64,10 @@ public class PatientSearchParameters {
         this.setFilterPatientsByLocation(Boolean.valueOf(context.getParameter("filterPatientsByLocation")));
         this.setFilterOnAllIdentifiers(Boolean.valueOf(context.getParameter("filterOnAllIdentifiers")));
         this.setLoginLocationUuid(context.getParameter("loginLocationUuid"));
+    }
+
+    private String[] getAddressConfigIfExists(Object addressConfig) {
+        return !Arrays.toString((Object[]) addressConfig).equals("[{}]") ? (String[]) addressConfig : null;
     }
 
     public String getIdentifier() {

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/patient/PatientSearchParameters.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/patient/PatientSearchParameters.java
@@ -3,6 +3,7 @@ package org.bahmni.module.bahmnicore.contract.patient;
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class PatientSearchParameters {
@@ -55,7 +56,7 @@ public class PatientSearchParameters {
         }
         this.setAddressFieldValue(context.getParameter("addressFieldValue"));
         Map parameterMap = context.getRequest().getParameterMap();
-        this.setAddressSearchResultFields((String[]) parameterMap.get("addressSearchResultsConfig"));
+        this.setAddressSearchResultFields(!Arrays.toString((Object[]) parameterMap.get("addressSearchResultsConfig")).equals("[{}]") ? (String[]) parameterMap.get("addressSearchResultsConfig") : null);
         this.setPatientSearchResultFields((String[]) parameterMap.get("patientSearchResultsConfig"));
         this.setPatientAttributes((String[]) parameterMap.get("patientAttributes"));
         this.setProgramAttributeFieldValue(context.getParameter("programAttributeFieldValue"));


### PR DESCRIPTION
- Search By ID is throwing error when the user is having values for address attributes and addressSearchResultFields as empty {}
- Added a boundry condition to check addressSearchResultFields