### PR TITLE
Siva Reddy | Caching maven dependencies

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-publish-package:
     name: Build and Publish package
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
@@ -17,6 +17,12 @@ jobs:
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Install compass
         run: |
           sudo apt-get install ruby-dev

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -13,6 +13,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Cache Maven packages
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
     - name: Install compass
       run: |
         sudo apt-get install ruby-dev


### PR DESCRIPTION
In this PR, caching the maven dependencies which improves the build time based on hash of pom files. If the content of pom.xml changes, GHA build creates hash again.

1st Run: 
<img width="656" alt="image" src="https://user-images.githubusercontent.com/56538788/220246313-8fffc736-8f04-468f-a5ca-f73bedb59db5.png">

2nd Run: 
<img width="920" alt="image" src="https://user-images.githubusercontent.com/56538788/220246353-1f179330-80bc-44eb-8de7-e2c5b2cd93bd.png">

3rd Run:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/56538788/220246731-ad80591c-7fa2-4309-be97-3d8cf1ccf9e3.png">


