### PR TITLE
Parvathy, Rahul | BAH-2822 | Fix. Redundancy In Dosing Units

### DIFF
--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4807,48 +4807,78 @@
             INSERT INTO role_privilege(role, privilege) VALUES ("Appointments:ManageAppointments", "Create Teleconsultation");
         </sql>
     </changeSet>
-    <changeSet id="bahmni-core-202303031445" author="Parvathy, Rahul">
+    <changeSet id="bahmni-core-202303201210" author="Parvathy, Rahul">
         <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="2">
-                SELECT count(*) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
-                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED');
-            </sqlCheck>
-            <sqlCheck expectedResult="2">
-                SELECT count(*) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
-                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED');
-            </sqlCheck>
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+                    AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
+                </sqlCheck>
+            </not>
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+                    AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
+                </sqlCheck>
+            </not>
         </preConditions>
-        <comment>Remove dosing unit duplicates from concept set</comment>
+        <comment>Delete Capsule(s) from Dosing Unit concept set</comment>
         <sql>
-            set @tablet_concept_set_id = (SELECT MAX(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
-            AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED'));
-
-            set @capsule_concept_set_id = (SELECT MAX(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
-            AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED'));
-
-            delete from concept_set where concept_set_id=@tablet_concept_set_id;
-            delete from concept_set where concept_set_id=@capsule_concept_set_id;
+            DELETE FROM concept_set WHERE concept_set.concept_set=(SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+            AND concept_set.concept_id=(SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
         </sql>
     </changeSet>
-    <changeSet id="bahmni-core-202303031500" author="Parvathy, Rahul">
+    <changeSet id="bahmni-core-202303201220" author="Parvathy, Rahul">
         <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="1">
-                SELECT count(*) FROM concept_name where name='Tablet(s)' and concept_name_type='FULLY_SPECIFIED';
-            </sqlCheck>
-            <sqlCheck expectedResult="1">
-                SELECT count(*) FROM concept_name where name='Capsule(s)' and concept_name_type='FULLY_SPECIFIED';
-            </sqlCheck>
-            <sqlCheck expectedResult="1">
-                SELECT count(*) FROM concept_name where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
+            <not>
+                <sqlCheck expectedResult="0">
+                    SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+                    AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
+                </sqlCheck>
+            </not>
+            <not>
+                <sqlCheck expectedResult="1">
+                    SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+                    AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
+                </sqlCheck>
+            </not>
+        </preConditions>
+        <comment>Delete Tablet(s) from Dosing Unit concept set</comment>
+        <sql>
+            DELETE FROM concept_set WHERE concept_set.concept_set=(SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true)
+            AND concept_set.concept_id=(SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED' AND locale_preferred=true);
+        </sql>
+    </changeSet>
+    <changeSet id="bahmni-core-202303200330" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet' AND concept_name_type = 'FULLY_SPECIFIED');
             </sqlCheck>
         </preConditions>
-        <comment>Renaming Concept Names of Dosing Units Type FULLY SPECIFIED</comment>
+        <comment>Add Tablet to Dosing Unit concept set</comment>
         <sql>
-            UPDATE concept_name SET name='Tablet' where name='Tablet(s)' and concept_name_type='FULLY_SPECIFIED';
+            SET @set_concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED');
 
-            UPDATE concept_name SET name='Capsule' where name='Capsule(s)' and concept_name_type='FULLY_SPECIFIED';
+            SET @tablet_concept_id = (SELECT concept_id FROM concept_name where name = 'Tablet' AND concept_name_type = 'FULLY_SPECIFIED');
 
-            UPDATE concept_name SET name='Unit' where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
+            INSERT INTO concept_set (concept_id, concept_set,sort_weight,creator,date_created,uuid) values (@tablet_concept_id, @set_concept_id, 1, 1, now(),uuid());
+        </sql>
+    </changeSet>
+    <changeSet id="bahmni-core-202303200340" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT count(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule' AND concept_name_type = 'FULLY_SPECIFIED');
+            </sqlCheck>
+        </preConditions>
+        <comment>Add Capsule to Dosing Unit concept set</comment>
+        <sql>
+            SET @set_concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED');
+
+            SET @capsule_concept_id = (SELECT concept_id FROM concept_name where name = 'Capsule' AND concept_name_type = 'FULLY_SPECIFIED');
+
+            INSERT INTO concept_set (concept_id, concept_set,sort_weight,creator,date_created,uuid) values (@capsule_concept_id, @set_concept_id, 1, 1, now(),uuid());
         </sql>
     </changeSet>
     <changeSet id="bahmni-core-202303061500" author="Parvathy, Rahul">
@@ -4870,6 +4900,17 @@
             UPDATE concept_name SET name='capsule' where name='capsule(s)' and concept_name_type='SHORT';
 
             UPDATE concept_name SET name='unit' where name='unit(s)' and concept_name_type='SHORT';
+        </sql>
+    </changeSet>
+    <changeSet id="bahmni-core-202303171600" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
+            </sqlCheck>
+        </preConditions>
+        <comment>Renaming Unit in Dosing Units Type FULLY SPECIFIED</comment>
+        <sql>
+            UPDATE concept_name SET name='Unit' where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
         </sql>
     </changeSet>
     <include file="addAtomfeedMigrations.xml"/>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4810,16 +4810,21 @@
     <changeSet id="bahmni-core-202303031445" author="Parvathy, Rahul">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="2">
-                SELECT count(*) FROM concept_set WHERE concept_id = 63 and concept_set = 62;
+                SELECT count(*) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED');
             </sqlCheck>
             <sqlCheck expectedResult="2">
-                SELECT count(*) FROM concept_set WHERE concept_id = 64 and concept_set = 62;
+                SELECT count(*) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+                AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED');
             </sqlCheck>
         </preConditions>
         <comment>Remove dosing unit duplicates from concept set</comment>
         <sql>
-            set @tablet_concept_set_id = 49;
-            set @capsule_concept_set_id = 50;
+            set @tablet_concept_set_id = (SELECT MAX(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+            AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Tablet(s)' AND concept_name_type = 'FULLY_SPECIFIED'));
+
+            set @capsule_concept_set_id = (SELECT MAX(concept_set_id) FROM concept_set WHERE concept_set = (SELECT concept_id FROM concept_name WHERE name = 'Dosing Units' AND concept_name_type = 'FULLY_SPECIFIED')
+            AND concept_id = (SELECT concept_id FROM concept_name WHERE name = 'Capsule(s)' AND concept_name_type = 'FULLY_SPECIFIED'));
 
             delete from concept_set where concept_set_id=@tablet_concept_set_id;
             delete from concept_set where concept_set_id=@capsule_concept_set_id;

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4807,6 +4807,65 @@
             INSERT INTO role_privilege(role, privilege) VALUES ("Appointments:ManageAppointments", "Create Teleconsultation");
         </sql>
     </changeSet>
+    <changeSet id="bahmni-core-202303031445" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="2">
+                SELECT count(*) FROM concept_set WHERE concept_id = 63 and concept_set = 62;
+            </sqlCheck>
+            <sqlCheck expectedResult="2">
+                SELECT count(*) FROM concept_set WHERE concept_id = 64 and concept_set = 62;
+            </sqlCheck>
+        </preConditions>
+        <comment>Remove dosing unit duplicates from concept set</comment>
+        <sql>
+            set @tablet_concept_set_id = 49;
+            set @capsule_concept_set_id = 50;
 
+            delete from concept_set where concept_set_id=@tablet_concept_set_id;
+            delete from concept_set where concept_set_id=@capsule_concept_set_id;
+        </sql>
+    </changeSet>
+    <changeSet id="bahmni-core-202303031500" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='Tablet(s)' and concept_name_type='FULLY_SPECIFIED';
+            </sqlCheck>
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='Capsule(s)' and concept_name_type='FULLY_SPECIFIED';
+            </sqlCheck>
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
+            </sqlCheck>
+        </preConditions>
+        <comment>Renaming Concept Names of Dosing Units Type FULLY SPECIFIED</comment>
+        <sql>
+            UPDATE concept_name SET name='Tablet' where name='Tablet(s)' and concept_name_type='FULLY_SPECIFIED';
+
+            UPDATE concept_name SET name='Capsule' where name='Capsule(s)' and concept_name_type='FULLY_SPECIFIED';
+
+            UPDATE concept_name SET name='Unit' where name='Unit(s)' and concept_name_type='FULLY_SPECIFIED';
+        </sql>
+    </changeSet>
+    <changeSet id="bahmni-core-202303061500" author="Parvathy, Rahul">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='tablet(s)' and concept_name_type='SHORT';
+            </sqlCheck>
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='capsule(s)' and concept_name_type='SHORT';
+            </sqlCheck>
+            <sqlCheck expectedResult="1">
+                SELECT count(*) FROM concept_name where name='unit(s)' and concept_name_type='SHORT';
+            </sqlCheck>
+        </preConditions>
+        <comment>Renaming Concept Names of Dosing Units Type SHORT</comment>
+        <sql>
+            UPDATE concept_name SET name='tablet' where name='tablet(s)' and concept_name_type='SHORT';
+
+            UPDATE concept_name SET name='capsule' where name='capsule(s)' and concept_name_type='SHORT';
+
+            UPDATE concept_name SET name='unit' where name='unit(s)' and concept_name_type='SHORT';
+        </sql>
+    </changeSet>
     <include file="addAtomfeedMigrations.xml"/>
 </databaseChangeLog>


### PR DESCRIPTION
In this PR, removal of duplicate values in dosing units and concept name updation has been done. The duplicacy was introduced by the change with id : bahmni-core-201409111200. The following sql queries have been added:

- Delete Duplicate Values [Tablet(s) and Capsule(s)]
- Update concept names [Tablet(s) → Tablet, Capsule(s) → Capsule, Unit(s) → Unit]