### PR TITLE
BAH-3181 | Enable locale specific concept search and also return FSN in defaultLocale

### DIFF
--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/contract/BahmniObservation.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/contract/BahmniObservation.java
@@ -43,6 +43,7 @@ public class BahmniObservation implements Comparable<BahmniObservation>{
     private String interpretation;
     private String status;
     private String encounterTypeName;
+    private String conceptFSN;
 
     @JsonIgnore
     private Serializable complexData;
@@ -430,5 +431,13 @@ public class BahmniObservation implements Comparable<BahmniObservation>{
 
     public void setEncounterTypeName(String encounterTypeName) {
         this.encounterTypeName = encounterTypeName;
+    }
+
+    public void setConceptFSN(String conceptFSN) {
+        this.conceptFSN = conceptFSN;
+    }
+
+    public String getConceptFSN() {
+        return this.conceptFSN;
     }
 }

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/OMRSObsToBahmniObsMapper.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/OMRSObsToBahmniObsMapper.java
@@ -2,13 +2,17 @@ package org.openmrs.module.bahmniemrapi.encountertransaction.mapper;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.openmrs.Concept;
+import org.openmrs.ConceptName;
 import org.openmrs.EncounterProvider;
 import org.openmrs.Obs;
+import org.openmrs.api.ConceptNameType;
 import org.openmrs.module.bahmniemrapi.drugorder.mapper.BahmniProviderMapper;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.bahmniemrapi.encountertransaction.mapper.parameters.AdditionalBahmniObservationFields;
 import org.openmrs.module.emrapi.encounter.ObservationMapper;
 import org.openmrs.module.emrapi.encounter.matcher.ObservationTypeMatcher;
+import org.openmrs.module.emrapi.utils.HibernateLazyLoader;
+import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 @Component(value = "omrsObsToBahmniObsMapper")
 public class OMRSObsToBahmniObsMapper {
@@ -33,9 +38,10 @@ public class OMRSObsToBahmniObsMapper {
 
     public Collection<BahmniObservation> map(List<Obs> obsList, Collection<Concept> rootConcepts) {
         Collection<BahmniObservation> bahmniObservations = new ArrayList<>();
+        Locale implementationLocale = LocaleUtility.getDefaultLocale();
         for (Obs obs : obsList) {
             if(observationTypeMatcher.getObservationType(obs).equals(ObservationTypeMatcher.ObservationType.OBSERVATION)){
-                BahmniObservation bahmniObservation =map(obs);
+                BahmniObservation bahmniObservation = map(obs, implementationLocale);
                 if(CollectionUtils.isNotEmpty(rootConcepts )){
                     bahmniObservation.setConceptSortWeight(ConceptSortWeightUtil.getSortWeightFor(bahmniObservation.getConcept().getName(), rootConcepts));
                 }
@@ -45,7 +51,7 @@ public class OMRSObsToBahmniObsMapper {
         return bahmniObservations;
     }
 
-    public BahmniObservation map(Obs obs) {
+    public BahmniObservation map(Obs obs, Locale implementationLocale) {
         if(obs == null)
              return null;
         String obsGroupUuid = obs.getObsGroup() == null? null : obs.getObsGroup().getUuid();
@@ -61,6 +67,28 @@ public class OMRSObsToBahmniObsMapper {
         for (EncounterProvider encounterProvider : obs.getEncounter().getEncounterProviders()) {
             additionalBahmniObservationFields.addProvider(bahmniProviderMapper.map(encounterProvider.getProvider()));
         }
-        return etObsToBahmniObsMapper.map(observationMapper.map(obs), additionalBahmniObservationFields, Collections.singletonList(obs.getConcept()), true);
+        BahmniObservation bahmniObservation = etObsToBahmniObsMapper.map(observationMapper.map(obs), additionalBahmniObservationFields, Collections.singletonList(obs.getConcept()), true);
+        bahmniObservation.setConceptFSN(getConceptFSNInDefaultLocale(obs, implementationLocale));
+        return bahmniObservation;
+    }
+
+    private String getConceptFSNInDefaultLocale(Obs obs, Locale implementationLocale) {
+        if (obs.getConcept() == null) {
+            return null;
+        }
+        Concept concept = new HibernateLazyLoader().load(obs.getConcept());
+        if (implementationLocale == null) {
+            return concept.getName().getName();
+        }
+        ConceptName fsn = concept.getName(implementationLocale, ConceptNameType.FULLY_SPECIFIED, null);
+        if (fsn == null) {
+            fsn = concept.getNames().stream().filter(name -> !name.getVoided() && name.getLocale().equals(implementationLocale)
+                    && name.getConceptNameType().equals(ConceptNameType.FULLY_SPECIFIED)).findFirst().orElse(null);
+        }
+        if (fsn != null) {
+            return fsn.getName();
+        } else {
+            return concept.getName().getName();
+        }
     }
 }

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/ObsRelationshipMapper.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/ObsRelationshipMapper.java
@@ -34,7 +34,7 @@ public class ObsRelationshipMapper {
                             new org.openmrs.module.bahmniemrapi.obsrelation.contract.ObsRelationship();
                     targetObsRelation.setRelationshipType(obsRelationship.getObsRelationshipType().getName());
                     targetObsRelation.setUuid(obsRelationship.getUuid());
-                    targetObsRelation.setTargetObs(OMRSObsToBahmniObsMapper.map(obsRelationship.getTargetObs()));
+                    targetObsRelation.setTargetObs(OMRSObsToBahmniObsMapper.map(obsRelationship.getTargetObs(), null));
                     bahmniObservation.setTargetObsRelation(targetObsRelation);
 //                    bahmniObservation.setProviders(providers);
                 }
@@ -47,8 +47,8 @@ public class ObsRelationshipMapper {
         List<BahmniObservation> bahmniObservations = new ArrayList<>();
         for (ObsRelationship obsRelationship : obsRelationships) {
 
-            BahmniObservation sourceObservation = OMRSObsToBahmniObsMapper.map(obsRelationship.getSourceObs());
-            BahmniObservation targetObservation = OMRSObsToBahmniObsMapper.map(obsRelationship.getTargetObs());
+            BahmniObservation sourceObservation = OMRSObsToBahmniObsMapper.map(obsRelationship.getSourceObs(), null);
+            BahmniObservation targetObservation = OMRSObsToBahmniObsMapper.map(obsRelationship.getTargetObs(), null);
             sourceObservation.setProviders(encounterProviderMapper.convert(obsRelationship.getSourceObs().getEncounter().getEncounterProviders()));
 
             org.openmrs.module.bahmniemrapi.obsrelation.contract.ObsRelationship targetObsRelation =

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/ObsRelationshipMapperTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/ObsRelationshipMapperTest.java
@@ -72,7 +72,7 @@ public class ObsRelationshipMapperTest {
         BahmniObservation sourceObservation = getBahmniObservation(sourceObsUuid);
         BahmniObservation targetObservation = getBahmniObservation(targetObsUuid);
 
-        when(OMRSObsToBahmniObsMapper.map(targetObs)).thenReturn(targetObservation);
+        when(OMRSObsToBahmniObsMapper.map(targetObs, null)).thenReturn(targetObservation);
 
         ArrayList<BahmniObservation> bahmniObservations = new ArrayList<>();
         bahmniObservations.add(sourceObservation);
@@ -81,7 +81,7 @@ public class ObsRelationshipMapperTest {
         List<BahmniObservation> mappedBahmniObservations = obsRelationshipMapper.map(bahmniObservations, "encounter-uuid");
         
         verify(obsrelationService).getRelationsWhereSourceObsInEncounter("encounter-uuid");
-        verify(OMRSObsToBahmniObsMapper, times(1)).map(targetObs);
+        verify(OMRSObsToBahmniObsMapper, times(1)).map(targetObs, null);
         assertEquals(2, mappedBahmniObservations.size());
         assertEquals(sourceObsUuid, mappedBahmniObservations.get(0).getUuid());
         assertEquals(targetObsUuid, mappedBahmniObservations.get(0).getTargetObsRelation().getTargetObs().getUuid());
@@ -112,8 +112,8 @@ public class ObsRelationshipMapperTest {
         BahmniObservation targetObservation1 = getBahmniObservation(targetObs1Uuid);
         BahmniObservation targetObservation2 = getBahmniObservation(targetObs2Uuid);
 
-        when(OMRSObsToBahmniObsMapper.map(targetObs1)).thenReturn(targetObservation1);
-        when(OMRSObsToBahmniObsMapper.map(targetObs2)).thenReturn(targetObservation2);
+        when(OMRSObsToBahmniObsMapper.map(targetObs1, null)).thenReturn(targetObservation1);
+        when(OMRSObsToBahmniObsMapper.map(targetObs2, null)).thenReturn(targetObservation2);
 
         ArrayList<BahmniObservation> bahmniObservations = new ArrayList<>();
         bahmniObservations.add(sourceObservation1);
@@ -124,7 +124,7 @@ public class ObsRelationshipMapperTest {
         List<BahmniObservation> mappedBahmniObservations = obsRelationshipMapper.map(bahmniObservations, "encounter-uuid");
 
         verify(obsrelationService).getRelationsWhereSourceObsInEncounter("encounter-uuid");
-        verify(OMRSObsToBahmniObsMapper, times(2)).map(any(Obs.class));
+        verify(OMRSObsToBahmniObsMapper, times(2)).map(any(Obs.class), any());
         assertEquals(4, mappedBahmniObservations.size());
         assertEquals(sourceObs1Uuid, mappedBahmniObservations.get(0).getUuid());
         assertEquals(targetObs1Uuid, mappedBahmniObservations.get(0).getTargetObsRelation().getTargetObs().getUuid());

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniBridge.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniBridge.java
@@ -18,7 +18,6 @@ import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.bahmniemrapi.encountertransaction.mapper.OMRSObsToBahmniObsMapper;
-import org.openmrs.module.emrapi.encounter.OrderMapper;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.emrapi.encounter.mapper.OrderMapper1_12;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -240,13 +239,13 @@ public class BahmniBridge {
 
     public BahmniObservation getChildObsFromParentObs(String parentObsGroupUuid, String childConceptName){
         Concept childConcept = conceptService.getConceptByName(childConceptName);
-        return omrsObsToBahmniObsMapper.map(obsDao.getChildObsFromParent(parentObsGroupUuid, childConcept));
+        return omrsObsToBahmniObsMapper.map(obsDao.getChildObsFromParent(parentObsGroupUuid, childConcept), null);
     }
 
     public BahmniObservation getLatestBahmniObservationFor(String conceptName){
         Obs obs = latestObs(conceptName);
         if(obs != null) {
-            return omrsObsToBahmniObsMapper.map(obs);
+            return omrsObsToBahmniObsMapper.map(obs, null);
         }
         return null;
     }

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImpl.java
@@ -21,9 +21,7 @@ import org.openmrs.api.VisitService;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.bahmniemrapi.encountertransaction.mapper.OMRSObsToBahmniObsMapper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
@@ -93,7 +91,7 @@ public class BahmniObsServiceImpl implements BahmniObsService {
     private List<BahmniObservation> convertToBahmniObservation(List<Obs> observations) {
         List<BahmniObservation> bahmniObservations = new ArrayList<>();
         for (Obs observation : observations) {
-            BahmniObservation bahmniObservation = omrsObsToBahmniObsMapper.map(observation);
+            BahmniObservation bahmniObservation = omrsObsToBahmniObsMapper.map(observation, null);
             bahmniObservation.setObservationDateTime(observation.getObsDatetime());
             bahmniObservations.add(bahmniObservation);
         }
@@ -265,7 +263,7 @@ public class BahmniObsServiceImpl implements BahmniObsService {
     @Override
     public BahmniObservation getBahmniObservationByUuid(String observationUuid) {
         Obs obs = obsService.getObsByUuid(observationUuid);
-        return omrsObsToBahmniObsMapper.map(obs);
+        return omrsObsToBahmniObsMapper.map(obs, null);
     }
 
     @Override
@@ -274,7 +272,7 @@ public class BahmniObsServiceImpl implements BahmniObsService {
         if (obs.getVoided()) {
             obs = getRevisionObs(obs);
         }
-        return omrsObsToBahmniObsMapper.map(obs);
+        return omrsObsToBahmniObsMapper.map(obs, null);
     }
 
     @Override

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniBridgeTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniBridgeTest.java
@@ -151,7 +151,7 @@ public class BahmniBridgeTest {
         bahmniObs.setUuid("observation uuid");
 
         PowerMockito.when(obsDao.getChildObsFromParent("parent obs uuid", vitalsConcept)).thenReturn(obs);
-        PowerMockito.when(omrsObsToBahmniObsMapper.map(obs)).thenReturn(bahmniObs);
+        PowerMockito.when(omrsObsToBahmniObsMapper.map(obs, null)).thenReturn(bahmniObs);
         Assert.assertEquals("observation uuid", bahmniBridge.getChildObsFromParentObs("parent obs uuid", "vital concept name").getUuid());
 
     }

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/BahmniObsServiceImplTest.java
@@ -214,12 +214,12 @@ public class BahmniObsServiceImplTest {
         Obs obs = new Obs();
         BahmniObservation expectedBahmniObservation = new BahmniObservation();
         when(obsService.getObsByUuid(observationUuid)).thenReturn(obs);
-        when(omrsObsToBahmniObsMapper.map(obs)).thenReturn(expectedBahmniObservation);
+        when(omrsObsToBahmniObsMapper.map(obs, null)).thenReturn(expectedBahmniObservation);
 
         BahmniObservation actualBahmniObservation = bahmniObsService.getBahmniObservationByUuid(observationUuid);
 
         verify(obsService, times(1)).getObsByUuid(observationUuid);
-        verify(omrsObsToBahmniObsMapper, times(1)).map(obs);
+        verify(omrsObsToBahmniObsMapper, times(1)).map(obs, null);
         assertNotNull(actualBahmniObservation);
         assertEquals(expectedBahmniObservation, actualBahmniObservation);
     }
@@ -262,7 +262,7 @@ public class BahmniObsServiceImplTest {
         when(visitDao.getVisitIdsFor(patientUuid, numberOfVisits)).thenReturn(visitIds);
         when(obsDao.getObsForFormBuilderForms(patientUuid, formNames, visitIds, encounters, null, null))
                 .thenReturn(singletonList(observation));
-        when(omrsObsToBahmniObsMapper.map(observation)).thenReturn(bahmniObservation);
+        when(omrsObsToBahmniObsMapper.map(observation, null)).thenReturn(bahmniObservation);
 
         Collection<BahmniObservation> bahmniObservations = bahmniObsService.getObsForFormBuilderForms(patientUuid,
                 formNames, numberOfVisits, null, null, patientProgramUuid);


### PR DESCRIPTION
Updated "/bahmnicore/observations" API to take in optional locale parameter, so that concepts are searched in the locale. Observation.conceptFSN returns the FSN in implementation/default locale