### PR TITLE
BAH-3336 | Patient Stage dropdown is empty in programs module [Env - Docker.standard]

### DIFF
--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4580,9 +4580,8 @@
         </preConditions>
         <comment>Update datatype of patient stage program attribute type</comment>
         <sql>
-            UPDATE program_attribute_type
-            SET datatype = 'org.openmrs.customdatatype.datatype.ConceptDatatype'
-            WHERE name = 'Stage';
+            UPDATE program_attribute_type SET datatype = 'org.openmrs.customdatatype.datatype.ConceptDatatype' WHERE
+            name = 'Stage' AND datatype = 'org.bahmni.module.bahmnicore.customdatatype.datatype.CodedConceptDatatype';
         </sql>
     </changeSet>
 

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4571,4 +4571,19 @@
         </sql>
     </changeSet>
 
+    <changeSet id="bahmni-core-20231206-bah-3336" author="Arjun">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="1">
+                SELECT COUNT(*) FROM program_attribute_type where name = 'Stage' AND datatype =
+                'org.bahmni.module.bahmnicore.customdatatype.datatype.CodedConceptDatatype';
+            </sqlCheck>
+        </preConditions>
+        <comment>Update datatype of patient stage program attribute type</comment>
+        <sql>
+            UPDATE program_attribute_type
+            SET datatype = 'org.openmrs.customdatatype.datatype.ConceptDatatype'
+            WHERE name = 'Stage';
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4571,7 +4571,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="bahmni-core-20231206-bah-3336" author="Arjun">
+    <changeSet id="bahmni-core-20231206-bah-3336" author="BAHMNI">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">
                 SELECT COUNT(*) FROM program_attribute_type where name = 'Stage' AND datatype =


### PR DESCRIPTION
[JIRA link](https://bahmni.atlassian.net/browse/BAH-3336)

# Summary

The dropdowns shown in programs module were not showing the linked conceptSet of Patient Stage post the OpenMRS upgrade. Changes at a database had to be made to support ConceptDataType in OpenMRS.