### PR TITLE
BAH-3513 | Fix. Disable encounter search when patient does not have visit

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImpl.java
@@ -58,6 +58,8 @@ public class BahmniFormDetailsServiceImpl implements BahmniFormDetailsService {
         Patient patient = getPatient(patientUuid);
         List<Visit> visits = visitService.getVisitsByPatient(patient);
 
+        //Warning: This check is needed to avoid getEncounters returning ALL non-voided encounters of all patients leading to OutOfMemoryError:Java Heap
+        //Refer: https://bahmni.atlassian.net/browse/BAH-3513
         if(visits.isEmpty())
             return Collections.emptyList();
 

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImpl.java
@@ -57,6 +57,10 @@ public class BahmniFormDetailsServiceImpl implements BahmniFormDetailsService {
     public Collection<FormDetails> getFormDetails(String patientUuid, FormType formType, int numberOfVisits) {
         Patient patient = getPatient(patientUuid);
         List<Visit> visits = visitService.getVisitsByPatient(patient);
+
+        if(visits.isEmpty())
+            return Collections.emptyList();
+
         List<Visit> limitedVisits = limitVisits(visits, numberOfVisits);
 
         List<Encounter> encounters = getEncounters(limitedVisits);

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImplTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/forms2/service/impl/BahmniFormDetailsServiceImplTest.java
@@ -166,14 +166,36 @@ public class BahmniFormDetailsServiceImplTest {
     @Test
     public void shouldReturnEmptyCollectionsOfFormDetailsIfPatientDoesNotHaveVisits() {
         when(visitService.getVisitsByPatient(patient)).thenReturn(Collections.emptyList());
-        shouldReturnEmptyCollectionsOfFormDetailsIfPatientDoesNotHaveVisitsOrEncounters();
+        Collection<FormDetails> formDetailsCollection = bahmniFormDetailsService.getFormDetails(patientUuid, FormType.FORMS2, -1);
+
+        assertEquals(0, formDetailsCollection.size());
+
+        verify(patientService, times(1)).getPatientByUuid(patientUuid);
+        verify(visitService, times(1)).getVisitsByPatient(patient);
+        verify(encounterService, times(0)).getEncounters(any(EncounterSearchCriteria.class));
+
+        verify(patient, times(0)).getPerson();
+        verify(obsService, times(0)).getObservations(anyListOf(Person.class),
+                anyListOf(Encounter.class), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(Boolean.class));
 
     }
 
     @Test
     public void shouldReturnEmptyCollectionsOfFormDetailsIfPatientDoesNotHaveEncounters() {
         when(encounterService.getEncounters(any(EncounterSearchCriteria.class))).thenReturn(Collections.emptyList());
-        shouldReturnEmptyCollectionsOfFormDetailsIfPatientDoesNotHaveVisitsOrEncounters();
+        Collection<FormDetails> formDetailsCollection = bahmniFormDetailsService.getFormDetails(patientUuid, FormType.FORMS2, -1);
+
+        assertEquals(0, formDetailsCollection.size());
+
+        verify(patientService, times(1)).getPatientByUuid(patientUuid);
+        verify(visitService, times(1)).getVisitsByPatient(patient);
+        verify(encounterService, times(1)).getEncounters(any(EncounterSearchCriteria.class));
+
+        verify(patient, times(0)).getPerson();
+        verify(obsService, times(0)).getObservations(anyListOf(Person.class),
+                anyListOf(Encounter.class), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+                any(Boolean.class));
     }
 
     @Test
@@ -312,23 +334,6 @@ public class BahmniFormDetailsServiceImplTest {
         verify(obsService, times(1)).getObservations(anyListOf(Person.class),
                 anyListOf(Encounter.class), any(), any(), any(), any(), any(), any(), any(), any(), any(),
                 any(Boolean.class));
-    }
-
-    private void shouldReturnEmptyCollectionsOfFormDetailsIfPatientDoesNotHaveVisitsOrEncounters() {
-
-        Collection<FormDetails> formDetailsCollection = bahmniFormDetailsService.getFormDetails(patientUuid, FormType.FORMS2, -1);
-
-        assertEquals(0, formDetailsCollection.size());
-
-        verify(patientService, times(1)).getPatientByUuid(patientUuid);
-        verify(visitService, times(1)).getVisitsByPatient(patient);
-        verify(encounterService, times(1)).getEncounters(any(EncounterSearchCriteria.class));
-
-        verify(patient, times(0)).getPerson();
-        verify(obsService, times(0)).getObservations(anyListOf(Person.class),
-                anyListOf(Encounter.class), any(), any(), any(), any(), any(), any(), any(), any(), any(),
-                any(Boolean.class));
-
     }
 
 }


### PR DESCRIPTION
- When a new patient uuid without visit is passed with this API `/openmrs/ws/rest/v1/bahmnicore/patient/4<uuid>/forms?formType=v2&numberOfVisits=10`, encounterSearch happens without any criteria.
- This returns all non-voided encounters from the database, due to which `OutOfMemory` happens.
- This fix adds a check the return empty list to the `getFormDetails` call, when no visit is returned for the patient.

Refactored test accordingly to validation getEncounter is not called when visits is empty.

JIRA: https://bahmni.atlassian.net/browse/BAH-3513