### PR TITLE
BAH-4026 | Raise Sample event when the concept class is Specimen

### DIFF
--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/contract/Sample.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/contract/Sample.java
@@ -1,10 +1,11 @@
 package org.bahmni.module.referencedata.labconcepts.contract;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class Sample extends Resource {
     private String shortName;
-    public static final String SAMPLE_CONCEPT_CLASS = "Sample";
+    public static final List<String> SAMPLE_CONCEPT_CLASSES = Arrays.asList("Sample", "Specimen");
     private Double sortOrder;
     private List<ResourceReference> tests;
     private List<ResourceReference> panels;

--- a/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AllSamplesMapper.java
+++ b/reference-data/api/src/main/java/org/bahmni/module/referencedata/labconcepts/mapper/AllSamplesMapper.java
@@ -3,7 +3,7 @@ package org.bahmni.module.referencedata.labconcepts.mapper;
 import org.bahmni.module.referencedata.labconcepts.contract.AllSamples;
 import org.openmrs.Concept;
 
-import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASS;
+import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASSES;
 
 
 public class AllSamplesMapper extends ResourceMapper {
@@ -18,7 +18,7 @@ public class AllSamplesMapper extends ResourceMapper {
         allSamples.setDescription(ConceptExtension.getDescription(allSamplesConcept));
 
         for (Concept setMember : allSamplesConcept.getSetMembers()) {
-            if (ConceptExtension.isOfConceptClass(setMember, SAMPLE_CONCEPT_CLASS)) {
+            if (ConceptExtension.isOfAnyConceptClass(setMember, SAMPLE_CONCEPT_CLASSES)) {
                 SampleMapper sampleMapper = new SampleMapper();
                 allSamples.addSample(sampleMapper.map(setMember));
             }

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SaleableTypeEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SaleableTypeEvent.java
@@ -17,7 +17,7 @@ import static org.bahmni.module.referencedata.labconcepts.contract.Department.DE
 import static org.bahmni.module.referencedata.labconcepts.contract.LabTest.LAB_TEST_CONCEPT_CLASSES;
 import static org.bahmni.module.referencedata.labconcepts.contract.Panel.LAB_SET_CONCEPT_CLASS;
 import static org.bahmni.module.referencedata.labconcepts.contract.RadiologyTest.RADIOLOGY_TEST_CONCEPT_CLASSES;
-import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASS;
+import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASSES;
 
 public class SaleableTypeEvent implements ConceptServiceOperationEvent {
 
@@ -29,9 +29,10 @@ public class SaleableTypeEvent implements ConceptServiceOperationEvent {
     private List<String> supportedOperations = Arrays.asList("saveConcept", "updateConcept", "retireConcept", "purgeConcept");
 
     private List<String> unhandledClasses = new ArrayList<String>(){{
-        addAll(Arrays.asList(LAB_SET_CONCEPT_CLASS, SAMPLE_CONCEPT_CLASS, DEPARTMENT_CONCEPT_CLASS));
+        addAll(Arrays.asList(LAB_SET_CONCEPT_CLASS, DEPARTMENT_CONCEPT_CLASS));
         addAll(LAB_TEST_CONCEPT_CLASSES);
         addAll(RADIOLOGY_TEST_CONCEPT_CLASSES);
+        addAll(SAMPLE_CONCEPT_CLASSES);
     }};
     private List<String> unhandledConcepsByName = Arrays.asList(ALL_SAMPLES, ALL_TESTS_AND_PANELS);
 

--- a/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SampleEvent.java
+++ b/reference-data/omod/src/main/java/org/bahmni/module/referencedata/labconcepts/model/event/SampleEvent.java
@@ -2,8 +2,8 @@ package org.bahmni.module.referencedata.labconcepts.model.event;
 
 import org.openmrs.Concept;
 
-import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASS;
-import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfConceptClass;
+import static org.bahmni.module.referencedata.labconcepts.contract.Sample.SAMPLE_CONCEPT_CLASSES;
+import static org.bahmni.module.referencedata.labconcepts.mapper.ConceptExtension.isOfAnyConceptClass;
 
 public class SampleEvent extends ConceptOperationEvent {
 
@@ -14,7 +14,7 @@ public class SampleEvent extends ConceptOperationEvent {
 
     @Override
     public boolean isResourceConcept(Concept concept) {
-        return isOfConceptClass(concept, SAMPLE_CONCEPT_CLASS);
+        return isOfAnyConceptClass(concept, SAMPLE_CONCEPT_CLASSES);
     }
 
 

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/labconcepts/advice/ConceptServiceEventInterceptorTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/labconcepts/advice/ConceptServiceEventInterceptorTest.java
@@ -55,7 +55,7 @@ public class ConceptServiceEventInterceptorTest {
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        concept = new ConceptBuilder().withClass(Sample.SAMPLE_CONCEPT_CLASS).withUUID(SampleEventTest.SAMPLE_CONCEPT_UUID).build();
+        concept = new ConceptBuilder().withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(0)).withUUID(SampleEventTest.SAMPLE_CONCEPT_UUID).build();
 
         Concept parentConcept = new ConceptBuilder().withName(AllSamples.ALL_SAMPLES).withSetMember(concept).build();
 

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/labconcepts/model/event/SampleEventTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/labconcepts/model/event/SampleEventTest.java
@@ -34,7 +34,11 @@ import static org.mockito.Mockito.when;
 public class SampleEventTest {
     public static final String SAMPLE_CONCEPT_UUID = "aebc57b7-0683-464e-ac48-48b8838abdfc";
 
+    public static final String SPECIMEN_CONCEPT_UUID = "aebc57b7-0683-464e-ac48-48b8838abdff";
+
     private Concept concept;
+
+    private Concept specimenConcept;
 
     @Mock
     private ConceptService conceptService;
@@ -45,6 +49,8 @@ public class SampleEventTest {
         MockitoAnnotations.initMocks(this);
 
         concept = new ConceptBuilder().withClass("Sample").withUUID(SAMPLE_CONCEPT_UUID).build();
+
+        specimenConcept = new ConceptBuilder().withClass("Specimen").withUUID(SPECIMEN_CONCEPT_UUID).build();
 
         parentConcept = new ConceptBuilder().withName(AllSamples.ALL_SAMPLES).withSetMember(concept).build();
 
@@ -63,6 +69,16 @@ public class SampleEventTest {
     public void createEventForSampleEvent() throws Exception {
         Event event = new Operation(ConceptService.class.getMethod("saveConcept", Concept.class)).apply(new Object[]{concept}).get(0);
         Event anotherEvent = new Operation(ConceptService.class.getMethod("saveConcept", Concept.class)).apply(new Object[]{concept}).get(0);
+        assertNotNull(event);
+        assertFalse(event.getUuid().equals(anotherEvent.getUuid()));
+        assertEquals(event.getTitle(), "sample");
+        assertEquals(event.getCategory(), "lab");
+    }
+
+    @Test
+    public void createSampleEventForSpecimenConcept() throws Exception {
+        Event event = new Operation(ConceptService.class.getMethod("saveConcept", Concept.class)).apply(new Object[]{specimenConcept}).get(0);
+        Event anotherEvent = new Operation(ConceptService.class.getMethod("saveConcept", Concept.class)).apply(new Object[]{specimenConcept}).get(0);
         assertNotNull(event);
         assertFalse(event.getUuid().equals(anotherEvent.getUuid()));
         assertEquals(event.getTitle(), "sample");

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/AllSamplesMapperTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/AllSamplesMapperTest.java
@@ -36,6 +36,7 @@ public class AllSamplesMapperTest {
     private AllSamplesMapper allSamplesMapper;
     private SampleMapper sampleMapper;
     private Concept sampleConcept;
+    private Concept specimenConcept;
     private Date dateCreated;
     private Date dateChanged;
     private Concept labSampleConceptSet;
@@ -59,12 +60,17 @@ public class AllSamplesMapperTest {
         Concept testConcept = new ConceptBuilder().withUUID("Test UUID").withDateCreated(dateCreated).withClass(LabTest.LAB_TEST_CONCEPT_CLASSES.get(0)).withDescription("SomeDescription")
                 .withDateChanged(dateChanged).withShortName("ShortName").withName("Test concept").withDataType(ConceptDatatype.NUMERIC).build();
 
-        sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASS).
+        sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(0)).
                 withDateChanged(dateChanged).withSetMember(testConcept).withShortName("ShortName").withName("SampleName").build();
+
+        specimenConcept = new ConceptBuilder().withUUID("Specimen UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(1)).
+                withDateChanged(dateChanged).withSetMember(testConcept).withShortName("SpecimenShortName").withName("SpecimenName").build();
 
         labSampleConceptSet = new ConceptBuilder().withUUID("Lab Samples UUID").withDateCreated(dateCreated).withDateChanged(dateChanged)
                 .withName(AllSamples.ALL_SAMPLES).withClassUUID(ConceptClass.LABSET_UUID).withShortName("Lab samples short name").withDescription("Lab samples Description")
-                .withSetMember(sampleConcept).build();
+                .withSetMember(sampleConcept)
+                .withSetMember(specimenConcept)
+                .build();
 
         when(Context.getConceptService()).thenReturn(conceptService);
     }
@@ -80,7 +86,7 @@ public class AllSamplesMapperTest {
         assertEquals(dateChanged, labSamplesData.getLastUpdated());
         assertEquals("Lab samples Description", labSamplesData.getDescription());
         List<Sample> samples = labSamplesData.getSamples();
-        assertEquals(1, samples.size());
+        assertEquals(2, samples.size());
         assertEquals(sampleData.getId(), samples.get(0).getId());
     }
 

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/LabTestMapperTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/LabTestMapperTest.java
@@ -69,7 +69,7 @@ public class LabTestMapperTest {
                 .withDateChanged(dateChanged).withShortName("ShortName").withName("Test Name Here").withDataType(ConceptDatatype.NUMERIC).build();
         Concept testAndPanelsConcept = new ConceptBuilder().withUUID("Test and Panels UUID").withDateCreated(dateCreated).withClassUUID(ConceptClass.CONVSET_UUID)
                 .withDateChanged(dateChanged).withShortName("ShortName").withName(AllTestsAndPanels.ALL_TESTS_AND_PANELS).withSetMember(testConcept).build();
-        Concept sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASS).
+        Concept sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(0)).
                 withDateChanged(dateChanged).withSetMember(testConcept).withShortName("ShortName").withName("SampleName").build();
         Concept laboratoryConcept = new ConceptBuilder().withUUID("Laboratory UUID")
                 .withName(AllSamples.ALL_SAMPLES).withClassUUID(ConceptClass.LABSET_UUID)

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/PanelMapperTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/PanelMapperTest.java
@@ -69,7 +69,7 @@ public class PanelMapperTest {
                 .withSetMember(testConcept).withDateChanged(dateChanged).withShortName("ShortName").withName("Panel Name Here").withDataType(ConceptDatatype.NUMERIC).build();
         Concept testAndPanelsConcept = new ConceptBuilder().withUUID("Test and Panels UUID").withDateCreated(dateCreated).withClassUUID(ConceptClass.CONVSET_UUID)
                 .withDateChanged(dateChanged).withShortName("ShortName").withName(AllTestsAndPanels.ALL_TESTS_AND_PANELS).withSetMember(panelConcept).build();
-        Concept sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASS).
+        Concept sampleConcept = new ConceptBuilder().withUUID("Sample UUID").withDateCreated(dateCreated).withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(0)).
                 withDateChanged(dateChanged).withSetMember(panelConcept).withShortName("ShortName").withName("SampleName").build();
         Concept departmentConcept = new ConceptBuilder().withUUID("Department UUID").withDateCreated(dateCreated).
                 withDateChanged(dateChanged).withClass("Department").withClassUUID(ConceptClass.CONVSET_UUID).withSetMember(panelConcept).withDescription("Some Description").withName("Department Name").build();

--- a/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/SampleMapperTest.java
+++ b/reference-data/omod/src/test/java/org/bahmni/module/referencedata/web/contract/mapper/SampleMapperTest.java
@@ -55,7 +55,7 @@ public class SampleMapperTest {
         when(Context.getLocale()).thenReturn(defaultLocale);
         sampleConcept = new ConceptBuilder().forSample().withShortName("ShortName").build();
         allSamplesConcept = new ConceptBuilder().withUUID("Laboratory UUID")
-                .withName(AllSamples.ALL_SAMPLES).withClass(Sample.SAMPLE_CONCEPT_CLASS)
+                .withName(AllSamples.ALL_SAMPLES).withClass(Sample.SAMPLE_CONCEPT_CLASSES.get(0))
                 .withSetMember(sampleConcept).build();
         ConceptSet conceptSet = createConceptSet(allSamplesConcept, sampleConcept);
         sortOrder = Double.valueOf(22);


### PR DESCRIPTION
This PR extends the `reference-data` OMOD to raise Atomfeed events of title Sample when a concept with class `Specimen` is saved. This is added to support sync of CIEL metadata mappings