### PR TITLE
BAH-3971 | Add. contextCookieExpirationTimeInMinutes Global Property

### DIFF
--- a/bahmnicore-omod/src/main/resources/config.xml
+++ b/bahmnicore-omod/src/main/resources/config.xml
@@ -199,6 +199,11 @@
         <description>Boolean to enable sending sms when patient registers</description>
     </globalProperty>
 
+    <globalProperty>
+        <property>bahmni.contextCookieExpirationTimeInMinutes</property>
+        <defaultValue>0</defaultValue>
+        <description>Expiration time in minutes of the cookie that maintains the user's session context</description>
+    </globalProperty>
 
     <advice>
         <point>org.openmrs.api.PatientService</point>


### PR DESCRIPTION
JIRA -> [BAH-3971](https://bahmni.atlassian.net/browse/BAH-3971)

This PR introduces the `contextCookieExpirationTimeInMinutes` global property via `config.xml`. This property defines the expiration time of the cookie that maintains the user's session context. It ensures that the user's session remains active for a specified duration, enhancing the user experience and security.