### PR TITLE
BAH-4065 | Fix. Get Concept by FSN should return only unretired concepts

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/impl/BahmniConceptDaoImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/dao/impl/BahmniConceptDaoImpl.java
@@ -98,6 +98,7 @@ public class BahmniConceptDaoImpl implements BahmniConceptDao {
                 .createQuery("select concept " +
                         "from ConceptName as conceptName " +
                         "where conceptName.conceptNameType ='FULLY_SPECIFIED' and conceptName.voided = false" +
+                        " and conceptName.concept.retired = false" +
                         " and lower(conceptName.name) in (:conceptNames)").setParameterList("conceptNames", lowerCaseConceptNames).list();
         return concepts;
     }


### PR DESCRIPTION
This PR fixes the `getConceptsByFullySpecifiedName` method to return only the concepts which are not retired.

This fix is essential when using concepts from CIEL dictionary where there are concepts which are retired but their associated concept name are not voided.

Example: https://app.staging.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/140156/
https://app.staging.openconceptlab.org/#/orgs/CIEL/sources/CIEL/concepts/1342/