### PR TITLE
BAH-4194 | Extend drug order config concept metadata to include UUID of concepts

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/drugorder/ConceptData.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/contract/drugorder/ConceptData.java
@@ -6,6 +6,7 @@ import org.openmrs.api.context.Context;
 
 public class ConceptData {
     private String name;
+    private String uuid;
     private String rootConcept;
 
     public ConceptData() {
@@ -14,6 +15,7 @@ public class ConceptData {
     public ConceptData(Concept concept) {
         if(concept != null){
             this.name = concept.getName(Context.getLocale()).getName();
+            this.uuid = concept.getUuid();
         }
     }
 
@@ -31,5 +33,13 @@ public class ConceptData {
 
     public void setRootConcept(String rootConcept) {
         this.rootConcept = rootConcept;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
     }
 }


### PR DESCRIPTION
This PR extends the `/openmrs/ws/rest/v1/bahmnicore/config/drugOrders` API to include UUID for the concept elements that are included as part of the following attributes of the response
- doseUnits
- routes 
- durationUnits
- dispensingUnits
- dosingInstructions

JIRA: https://bahmni.atlassian.net/browse/BAH-4194