### PR TITLE
BAH-4554 Set sonar.projectName to bahmni-core for discoverability

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,3 @@
 sonar.projectKey=Bahmni_bahmni-core
 sonar.organization=bahmni
+sonar.projectName=bahmni-core


### PR DESCRIPTION
SonarCloud was displaying the project as **"Bahmni EMR Core"** (pulled from `pom.xml` `<name>`). This makes it hard to find when searching by repo name.

Adding `sonar.projectName=bahmni-core` to `sonar-project.properties` so it matches the GitHub repository name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)