### PR TITLE
BAH-4430: Add noKnownAllergyUuid as a global property

### DIFF
--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4683,4 +4683,17 @@
         <sqlFile path="V1_99_WardsListSql.sql"/>
     </changeSet>
 
+    <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add no known allergy concept global property</comment>
+        <sql>
+            insert into global_property (property, property_value, description, uuid)
+            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4686,13 +4686,13 @@
     <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyUuid'
             </sqlCheck>
         </preConditions>
         <comment>Add no known allergy concept global property</comment>
         <sql>
             insert into global_property (property, property_value, description, uuid)
-            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+            values ('allergy.concept.noKnownAllergyUuid', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
         </sql>
     </changeSet>
 

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4690,13 +4690,13 @@
     <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyUuid'
             </sqlCheck>
         </preConditions>
         <comment>Add no known allergy concept global property</comment>
         <sql>
             insert into global_property (property, property_value, description, uuid)
-            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+            values ('allergy.concept.noKnownAllergyUuid', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
         </sql>
     </changeSet>
 

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4700,4 +4700,17 @@
         </sql>
     </changeSet>
 
+    <changeSet id="bahmni-core-202604231219" author="Vivek Kumar Pandey">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.otherAllergenUuid'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add other allergen non coded concept global property</comment>
+        <sql>
+            insert into global_property (property, property_value, description, uuid)
+            values ('allergy.concept.otherAllergenUuid', 'df2e7016-5f2e-41f4-b376-73762429a1c5', 'UUID for the allergy other non coded concept', uuid());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4687,4 +4687,17 @@
         <sqlFile path="V1_100_AddActivePatientWithLabOrdersQuery.sql"/>
     </changeSet>
 
+    <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add no known allergy concept global property</comment>
+        <sql>
+            insert into global_property (property, property_value, description, uuid)
+            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- Adds `noKnownAllergyUuid` as a global property via Liquibase migration
- Renames from `noKnownAllergyCode` to `noKnownAllergyUuid` for consistency
- Adds `otherAllergenUuid` as a global property for the allergy other non coded concept

## Jira
[BAH-4430](https://bahmni.atlassian.net/browse/BAH-4430)

## Test plan
- [ ] Verify Liquibase migration runs successfully on startup
- [ ] Confirm `noKnownAllergyUuid` global property is created in OpenMRS admin
- [ ] Confirm `otherAllergenUuid` global property is created in OpenMRS admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BAH-4430]: https://bahmni.atlassian.net/browse/BAH-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added allergy-related configuration properties to the database during initialization, with safeguards to avoid duplicate entries on repeated upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->