### PR TITLE
BAH-4222|Add liquibase migration for active patients with lab orders SQL query 

### DIFF
--- a/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
+++ b/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
@@ -6,14 +6,16 @@ VALUES ('emrapi.sqlSearch.activePatientsWithLabOrders',
         'select distinct
           concat(pn.given_name, " ", pn.family_name) as name,
           pi.identifier as identifier,
-          concat("",p.uuid) as uuid
+          concat("",p.uuid) as uuid,
+          concat("",v.uuid) as activeVisitUuid
         from visit v
         join person_name pn on v.patient_id = pn.person_id and pn.voided = 0
         join patient_identifier pi on v.patient_id = pi.patient_id
         join patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
         join global_property gp on gp.property="bahmni.primaryIdentifierType" and gp.property_value=pit.uuid
         join person p on p.person_id = v.patient_id
-        join orders on orders.patient_id = v.patient_id
+        join location l on l.uuid = ${location_uuid} and v.location_id = l.location_id
+        join orders on orders.patient_id = v.patient_id and orders.voided = 0
         join order_type on orders.order_type_id = order_type.order_type_id and order_type.name = "Lab Order"
         where v.date_stopped is null AND v.voided = 0 and order_id not in
           (select obs.order_id

--- a/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
+++ b/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
@@ -1,0 +1,24 @@
+DELETE FROM global_property
+WHERE property = 'emrapi.sqlSearch.activePatientsWithLabOrders';
+
+INSERT INTO global_property (`property`, `property_value`, `description`, `uuid`)
+VALUES ('emrapi.sqlSearch.activePatientsWithLabOrders',
+        'select distinct
+          concat(pn.given_name, " ", pn.family_name) as name,
+          pi.identifier as identifier,
+          concat("",p.uuid) as uuid
+        from visit v
+        join person_name pn on v.patient_id = pn.person_id and pn.voided = 0
+        join patient_identifier pi on v.patient_id = pi.patient_id
+        join patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
+        join global_property gp on gp.property="bahmni.primaryIdentifierType" and gp.property_value=pit.uuid
+        join person p on p.person_id = v.patient_id
+        join orders on orders.patient_id = v.patient_id
+        join order_type on orders.order_type_id = order_type.order_type_id and order_type.name = "Lab Order"
+        where v.date_stopped is null AND v.voided = 0 and order_id not in
+          (select obs.order_id
+            from obs
+          where person_id = pn.person_id and order_id = orders.order_id)',
+        'Sql query to get list of active patients with lab orders',
+        uuid()
+);

--- a/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
+++ b/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
@@ -4,23 +4,23 @@ WHERE property = 'emrapi.sqlSearch.activePatientsWithLabOrders';
 INSERT INTO global_property (`property`, `property_value`, `description`, `uuid`)
 VALUES ('emrapi.sqlSearch.activePatientsWithLabOrders',
         'select distinct
-          concat(pn.given_name, " ", pn.family_name) as name,
+          concat(pn.given_name, ' ', ifnull(pn.family_name, '')) as name,
           pi.identifier as identifier,
           concat("",p.uuid) as uuid,
           concat("",v.uuid) as activeVisitUuid
         from visit v
-        join person_name pn on v.patient_id = pn.person_id and pn.voided = 0
-        join patient_identifier pi on v.patient_id = pi.patient_id
+        join person_name pn on v.patient_id = pn.person_id and pn.voided = 0 and pn.preferred = 1
+        join patient_identifier pi on v.patient_id = pi.patient_id and pi.voided = 0
         join patient_identifier_type pit on pi.identifier_type = pit.patient_identifier_type_id
         join global_property gp on gp.property="bahmni.primaryIdentifierType" and gp.property_value=pit.uuid
         join person p on p.person_id = v.patient_id
-        join location l on l.uuid = ${location_uuid} and v.location_id = l.location_id
+        join location l on l.uuid = ${visit_location_uuid} and v.location_id = l.location_id
         join orders on orders.patient_id = v.patient_id and orders.voided = 0
         join order_type on orders.order_type_id = order_type.order_type_id and order_type.name = "Lab Order"
         where v.date_stopped is null AND v.voided = 0 and order_id not in
           (select obs.order_id
             from obs
-          where person_id = pn.person_id and order_id = orders.order_id)',
+          where person_id = pn.person_id and order_id = orders.order_id and obs.order_id is not null)',
         'Sql query to get list of active patients with lab orders',
         uuid()
 );

--- a/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
+++ b/bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql
@@ -4,7 +4,7 @@ WHERE property = 'emrapi.sqlSearch.activePatientsWithLabOrders';
 INSERT INTO global_property (`property`, `property_value`, `description`, `uuid`)
 VALUES ('emrapi.sqlSearch.activePatientsWithLabOrders',
         'select distinct
-          concat(pn.given_name, ' ', ifnull(pn.family_name, '')) as name,
+          concat(pn.given_name, \' \', ifnull(pn.family_name, \'\')) as name,
           pi.identifier as identifier,
           concat("",p.uuid) as uuid,
           concat("",v.uuid) as activeVisitUuid

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4682,5 +4682,9 @@
         <comment>Update the wards list sql to optimize for MySQL 8 - Bahmni Standard 1.0</comment>
         <sqlFile path="V1_99_WardsListSql.sql"/>
     </changeSet>
+    <changeSet id="bahmni-4222-202505021800" author="Bahmni">
+        <comment>Add SQL query to get active patients with lab orders</comment>
+        <sqlFile path="V1_100_AddActivePatientWithLabOrdersQuery.sql"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4682,7 +4682,7 @@
         <comment>Update the wards list sql to optimize for MySQL 8 - Bahmni Standard 1.0</comment>
         <sqlFile path="V1_99_WardsListSql.sql"/>
     </changeSet>
-    <changeSet id="bahmni-4222-202505021800" author="Bahmni">
+    <changeSet id="bahmni-core-20250502-bah-4222" author="Bahmni">
         <comment>Add SQL query to get active patients with lab orders</comment>
         <sqlFile path="V1_100_AddActivePatientWithLabOrdersQuery.sql"/>
     </changeSet>


### PR DESCRIPTION
Implements BAH-4222 to add active patient list display on lab entry home page
                                                                                                            
  Backend Changes (bahmni-core)
  - File: `bahmnicore-omod/src/main/resources/V1_100_AddActivePatientWithLabOrdersQuery.sql`
  - Global property `emrapi.sqlSearch.activePatientsWithLabOrders`                                                                         
  - Query Details:                                                                                                                                       
    - Filters patients with active visits                                                                               
    - Filters for patients who have lab orders (order_type.name = "Lab Order", voided = 0)                                                                   
    - Uses location filtering via `${location_uuid}` parameter                                                                                               
    - Returns patient name, identifier, UUID, and activeVisitUuid                                                                                            
                                                                                                                                                             
  - Liquibase Migration: `bahmni-core/bahmnicore-omod/src/main/resources/liquibase.xml`                                                                  
    - Changeset ID: `bahmni-4222-202505021800`                                                                                                               
    - Runs once on database initialization  