### PR TITLE
BAH-4222 | Bump version to 2.0.1-SNAPSHOT for Liquibase migration dep…

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin</artifactId>

--- a/bahmni-emr-api/pom.xml
+++ b/bahmni-emr-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bahmni-mapping/pom.xml
+++ b/bahmni-mapping/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>bahmni-mapping</artifactId>
     <packaging>jar</packaging>

--- a/bahmni-test-commons/pom.xml
+++ b/bahmni-test-commons/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bahmnicore-api/pom.xml
+++ b/bahmnicore-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-api</artifactId>
     <packaging>jar</packaging>

--- a/bahmnicore-omod/pom.xml
+++ b/bahmnicore-omod/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-omod</artifactId>
     <packaging>jar</packaging>

--- a/bahmnicore-ui/pom.xml
+++ b/bahmnicore-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-ui</artifactId>
     <packaging>jar</packaging>

--- a/obs-relation/pom.xml
+++ b/obs-relation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>obs-relationship</artifactId>
     <packaging>jar</packaging>

--- a/openmrs-elis-atomfeed-client-omod/pom.xml
+++ b/openmrs-elis-atomfeed-client-omod/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>openelis-atomfeed-client-omod</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.bahmni.module</groupId>
     <artifactId>bahmni</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Bahmni EMR Core</name>
     <url>https://github.com/Bahmni/bahmni-core.git</url>

--- a/reference-data/api/pom.xml
+++ b/reference-data/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reference-data/omod/pom.xml
+++ b/reference-data/omod/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reference-data/pom.xml
+++ b/reference-data/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>reference-data</artifactId>
     <packaging>pom</packaging>

--- a/vagrant-deploy/pom.xml
+++ b/vagrant-deploy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Updated all  pom.xml files from version 2.0.0 (release) to 2.0.1-SNAPSHOT                                                           
                                                                                                                                                      
  Purpose: Enable CI to deploy the OMOD to Nexus. The CI build_publish.yml workflow only deploys artifacts with SNAPSHOT versions. With version bumped  to SNAPSHOT, the new OMOD containing the Liquibase migration (V1_100_AddActivePatientWithLabOrdersQuery.sql) will be deployed to Nexus on merge.   
                                    