### PR TITLE
Fix. Nexus Authentication failure for build and publish package

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-publish-package:
     name: Build and Publish package
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'corretto'
+          cache: maven
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -9,11 +9,12 @@ jobs:
     name: Build and Publish package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'corretto'
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-publish-package:
     name: Build and Publish package
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 8
@@ -18,12 +18,6 @@ jobs:
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
       - name: Build and deploy with Maven
         run: |
           PROJECT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)

--- a/.github/workflows/release_deploy.yml
+++ b/.github/workflows/release_deploy.yml
@@ -9,11 +9,12 @@ jobs:
     name: Build and Release package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'corretto'
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD

--- a/.github/workflows/release_deploy.yml
+++ b/.github/workflows/release_deploy.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'corretto'
+          cache: maven
           server-id: nexus-sonatype
           server-username: NEXUS_USERNAME
           server-password: NEXUS_PASSWORD


### PR DESCRIPTION
This PR fixes the issue with Github actions failing with `UnAuthorized` error on build nd upload. Since the runner is changed, the cache needs to revalidated