### PR TITLE
BAH-4651 |  Remove nested bean definition from inside the TransactionProxyFactoryBean target              

### DIFF
--- a/bahmnicore-api/src/main/resources/moduleApplicationContext.xml
+++ b/bahmnicore-api/src/main/resources/moduleApplicationContext.xml
@@ -282,7 +282,15 @@
             <ref bean="transactionManager"/>
         </property>
         <property name="target">
-            <ref bean="bahmniEncounterMatchDecisionServiceTarget"/>
+            <bean class="org.bahmni.module.bahmnicore.service.impl.BahmniEncounterMatchDecisionServiceImpl" autowire="constructor">
+                <constructor-arg ref="visitService"/>
+                <constructor-arg ref="patientService"/>
+                <constructor-arg ref="locationService"/>
+                <constructor-arg ref="providerService"/>
+                <constructor-arg ref="encounterService"/>
+                <constructor-arg ref="encounterSessionMatcher"/>
+                <constructor-arg ref="bahmniVisitLocationService"/>
+            </bean>
         </property>
         <property name="preInterceptors">
             <ref bean="serviceInterceptors"/>
@@ -291,15 +299,4 @@
             <ref bean="transactionAttributeSource"/>
         </property>
     </bean>
-
-    <bean id="bahmniEncounterMatchDecisionServiceTarget" class="org.bahmni.module.bahmnicore.service.impl.BahmniEncounterMatchDecisionServiceImpl" autowire="constructor">
-        <constructor-arg ref="visitService"/>
-        <constructor-arg ref="patientService"/>
-        <constructor-arg ref="locationService"/>
-        <constructor-arg ref="providerService"/>
-        <constructor-arg ref="encounterService"/>
-        <constructor-arg ref="encounterSessionMatcher"/>
-        <constructor-arg ref="bahmniVisitLocationService"/>
-    </bean>
-
 </beans>

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniEncounterController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniEncounterController.java
@@ -40,7 +40,6 @@ public class BahmniEncounterController extends BaseRestController {
     private EncounterTransactionMapper encounterTransactionMapper;
     private BahmniEncounterTransactionService bahmniEncounterTransactionService;
     private BahmniEncounterTransactionMapper bahmniEncounterTransactionMapper;
-    @Autowired
     private BahmniEncounterMatchDecisionService encounterMatchDecisionService;
     private static Logger logger = LogManager.getLogger(BahmniEncounterController.class);
 


### PR DESCRIPTION
Changes:                                                                                                                                                                                                       
  - Refactored moduleApplicationContext.xml to remove nested bean definition from inside the TransactionProxyFactoryBean target                                                                                  
  - Simplified BahmniEncounterController by removing 1 line (likely a field or log statement)                                                                                                                    
                                                                                                                                                                                                               
  Impact:                                                                                                                                                                                                        
  - Cleaner Spring bean configuration structure with explicit bean references instead of inline definitions                                                                                                    
  - More maintainable XML configuration following OpenMRS patterns    