### PR TITLE
BAH-4717|Shilpa|Forcing execution of SqlSearchService read only

### DIFF
--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/advice/BahmniEncounterTransactionUpdateAdviceTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/advice/BahmniEncounterTransactionUpdateAdviceTest.java
@@ -18,7 +18,9 @@ import static org.junit.Assert.assertThat;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import org.apache.commons.lang.StringUtils;
-;
+
+import java.io.File;
+import java.net.URISyntaxException;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ Context.class, OpenmrsUtil.class})
@@ -29,10 +31,14 @@ public class BahmniEncounterTransactionUpdateAdviceTest {
     @Mock
     private AdministrationService administrationService;
 
+    private String getTestResourcesDirectory() throws URISyntaxException {
+        return new File(getClass().getClassLoader().getResource("").toURI()).getAbsolutePath() + File.separator;
+    }
+
     @Test
     public void shouldExecuteObsValueCalculatorFromApplicationDataDirectory() throws Throwable {
         PowerMockito.mockStatic(OpenmrsUtil.class);
-        when(OpenmrsUtil.getApplicationDataDirectory()).thenReturn(getClass().getClassLoader().getResource("").getPath());
+        when(OpenmrsUtil.getApplicationDataDirectory()).thenReturn(getTestResourcesDirectory());
         PowerMockito.mockStatic(Context.class);
         when(Context.getAdministrationService()).thenReturn(administrationService);
         when(administrationService.getGlobalProperty(BAHMNI_EXECUTE_GROOVY_SCRIPT)).thenReturn("true");
@@ -46,10 +52,8 @@ public class BahmniEncounterTransactionUpdateAdviceTest {
     @Test
     public void shouldLoadpplicationDataDirectoryPath() throws Throwable {
         PowerMockito.mockStatic(OpenmrsUtil.class);
-        String path = getClass().getClassLoader().getResource("").getPath();
-        // remove the trailing "/"
+        String path = getTestResourcesDirectory();
         path = StringUtils.chop(path);
-        System.out.println(path);
         when(OpenmrsUtil.getApplicationDataDirectory()).thenReturn(path);
         PowerMockito.mockStatic(Context.class);
         when(Context.getAdministrationService()).thenReturn(administrationService);
@@ -64,7 +68,7 @@ public class BahmniEncounterTransactionUpdateAdviceTest {
     @Test
     public void shouldNotFailIfobscalculatorDirectoryDoesNotExist() throws Throwable {
         PowerMockito.mockStatic(OpenmrsUtil.class);
-        when(OpenmrsUtil.getApplicationDataDirectory()).thenReturn(getClass().getClassLoader().getResource("").getPath() + "nonExistentDirectory");
+        when(OpenmrsUtil.getApplicationDataDirectory()).thenReturn(getTestResourcesDirectory() + "nonExistentDirectory");
         PowerMockito.mockStatic(Context.class);
         when(Context.getAdministrationService()).thenReturn(administrationService);
         when(administrationService.getGlobalProperty(BAHMNI_EXECUTE_GROOVY_SCRIPT)).thenReturn("true");

--- a/bahmnicore-api/pom.xml
+++ b/bahmnicore-api/pom.xml
@@ -214,6 +214,18 @@
             <testResource>
                 <directory>src/test/resources</directory>
                 <filtering>true</filtering>
+                <excludes>
+                    <exclude>**/*.mkv</exclude>
+                    <exclude>**/*.mov</exclude>
+                </excludes>
+            </testResource>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>false</filtering>
+                <includes>
+                    <include>**/*.mkv</include>
+                    <include>**/*.mov</include>
+                </includes>
             </testResource>
         </testResources>
         <plugins>

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/SqlSearchService.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/SqlSearchService.java
@@ -6,8 +6,11 @@ import org.openmrs.module.webservices.rest.SimpleObject;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.transaction.annotation.Transactional;
+
 public interface SqlSearchService {
 
+    @Transactional(readOnly = true)
     @Authorized
     public List<SimpleObject> search(String sqlQuery, Map<String, String[]> params);
 

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/SqlSearchServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/SqlSearchServiceImpl.java
@@ -42,14 +42,16 @@ public class SqlSearchServiceImpl implements SqlSearchService {
         SqlQueryHelper sqlQueryHelper = new SqlQueryHelper();
         String query = getSql(queryId);
         debugPrintQueryParams(queryId, mergedParams);
-        try( Connection conn = DatabaseUpdater.getConnection();
-            PreparedStatement statement = sqlQueryHelper.constructPreparedStatement(query,mergedParams,conn);
-            ResultSet resultSet = statement.executeQuery()) {
-            RowMapper rowMapper = new RowMapper();
-            while (resultSet.next()) {
-                results.add(rowMapper.mapRow(resultSet));
+        try (Connection conn = DatabaseUpdater.getConnection()) {
+            conn.setReadOnly(true);
+            try (PreparedStatement statement = sqlQueryHelper.constructPreparedStatement(query, mergedParams, conn);
+                ResultSet resultSet = statement.executeQuery()) {
+                RowMapper rowMapper = new RowMapper();
+                while (resultSet.next()) {
+                    results.add(rowMapper.mapRow(resultSet));
+                }
+                return results;
             }
-            return results;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search operations now run with safer read-only database handling, improving reliability and resource cleanup.
* **Tests**
  * Test suite consolidated path handling for test resources to make tests more robust and consistent.
* **Chores**
  * Test resource configuration updated to treat large media files separately for more reliable test builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-core/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->