### PR TITLE
Add no known allergy concept UUID as global property

### DIFF
--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4690,13 +4690,13 @@
     <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">
-                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyUuid'
             </sqlCheck>
         </preConditions>
         <comment>Add no known allergy concept global property</comment>
         <sql>
             insert into global_property (property, property_value, description, uuid)
-            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+            values ('allergy.concept.noKnownAllergyUuid', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
         </sql>
     </changeSet>
 

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4687,4 +4687,17 @@
         <sqlFile path="V1_100_AddActivePatientWithLabOrdersQuery.sql"/>
     </changeSet>
 
+    <changeSet id="bahmni-core-202601151218" author="Vivek Kumar Pandey">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property where property = 'allergy.concept.noKnownAllergyCode'
+            </sqlCheck>
+        </preConditions>
+        <comment>Add no known allergy concept global property</comment>
+        <sql>
+            insert into global_property (property, property_value, description, uuid)
+            values ('allergy.concept.noKnownAllergyCode', 'f535bd4e-33ff-4f35-bf7c-189e07d1ac90', 'Specifies the uuid of no known allergy concept', uuid());
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

- Adds a new global property `allergy.concept.noKnownAllergyUuid` via a Liquibase changeset in `bahmnicore-omod`
- The property stores the UUID of the "No Known Allergy" concept, enabling frontends to identify and handle this special allergy entry (e.g. strike-through display, localisation support) without hardcoding the UUID or relying on text matching

## Changes

- `bahmnicore-omod/src/main/resources/liquibase.xml`: adds changeset `bahmni-core-202601151218` with a pre-condition guard (`MARK_RAN` if property already exists)

## Test plan

- [ ] Run Bahmni with this module — verify `allergy.concept.noKnownAllergyUuid` appears in OpenMRS global properties after startup
- [ ] Run the changeset a second time — confirm it is skipped (`MARK_RAN`) without error
- [ ] Verify existing allergy workflows are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured system to properly initialize allergy tracking settings on first deployment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-core/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->