### PR TITLE
BAH-4779 | Add. Program-Linked Patient Identifiers To Enrollment Resource

### DIFF
--- a/bahmnicore-omod/src/main/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResource.java
+++ b/bahmnicore-omod/src/main/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResource.java
@@ -12,6 +12,7 @@ package org.openmrs.module.bahmnicore.web.v1_0.resource;
 
 import org.bahmni.module.bahmnicore.service.BahmniProgramWorkflowService;
 import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientProgram;
 import org.openmrs.PatientProgramAttribute;
 import org.openmrs.Program;
@@ -41,6 +42,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Resource(name = RestConstants.VERSION_1 + "/bahmniprogramenrollment", supportedClass = PatientProgram.class, supportedOpenmrsVersions = {"1.12.* - 2.*"}, order = 0)
 public class BahmniProgramEnrollmentResource extends ProgramEnrollmentResource1_10 {
@@ -66,6 +68,13 @@ public class BahmniProgramEnrollmentResource extends ProgramEnrollmentResource1_
         return Context.getService(BahmniProgramWorkflowService.class).getAllowedStatesForProgram(program);
     }
 
+    @PropertyGetter("identifiers")
+    public static List<PatientIdentifier> getIdentifiers(PatientProgram instance) {
+        return instance.getPatient().getActiveIdentifiers().stream()
+                .filter(id -> instance.equals(id.getPatientProgram()))
+                .collect(Collectors.toList());
+    }
+
     @Override
     public PatientProgram newDelegate() {
         return new PatientProgram();
@@ -78,11 +87,14 @@ public class BahmniProgramEnrollmentResource extends ProgramEnrollmentResource1_
             parentRep.addProperty("attributes", Representation.REF);
             parentRep.addProperty("episodeUuid");
             parentRep.addProperty("allowedStates");
+            parentRep.addProperty("identifiers", Representation.REF);
             return parentRep;
         } else if (rep instanceof FullRepresentation) {
+            parentRep.addProperty("patient", Representation.FULL);
             parentRep.addProperty("attributes", Representation.DEFAULT);
             parentRep.addProperty("episodeUuid");
             parentRep.addProperty("allowedStates");
+            parentRep.addProperty("identifiers", Representation.FULL);
             return parentRep;
         } else {
             return null;

--- a/bahmnicore-omod/src/test/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResourceIdentifiersTest.java
+++ b/bahmnicore-omod/src/test/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResourceIdentifiersTest.java
@@ -1,0 +1,93 @@
+package org.openmrs.module.bahmnicore.web.v1_0.resource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientProgram;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("org.openmrs.module.webservices.rest.web.RestConstants")
+public class BahmniProgramEnrollmentResourceIdentifiersTest {
+
+    @Test
+    public void shouldReturnIdentifiersLinkedToProgram() {
+        PatientProgram program = programWithPatient();
+        PatientIdentifier linkedIdentifier = identifierLinkedTo(program);
+        program.getPatient().addIdentifier(linkedIdentifier);
+
+        List<PatientIdentifier> result = BahmniProgramEnrollmentResource.getIdentifiers(program);
+
+        assertEquals(1, result.size());
+        assertEquals(linkedIdentifier, result.get(0));
+    }
+
+    @Test
+    public void shouldExcludeIdentifiersFromDifferentProgram() {
+        PatientProgram program = programWithPatient();
+        PatientProgram otherProgram = programWithPatient();
+        PatientIdentifier otherIdentifier = identifierLinkedTo(otherProgram);
+        program.getPatient().addIdentifier(otherIdentifier);
+
+        List<PatientIdentifier> result = BahmniProgramEnrollmentResource.getIdentifiers(program);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldExcludeIdentifiersWithNoProgram() {
+        PatientProgram program = programWithPatient();
+        PatientIdentifier unlinkedIdentifier = new PatientIdentifier();
+        program.getPatient().addIdentifier(unlinkedIdentifier);
+
+        List<PatientIdentifier> result = BahmniProgramEnrollmentResource.getIdentifiers(program);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenPatientHasNoIdentifiers() {
+        PatientProgram program = programWithPatient();
+
+        List<PatientIdentifier> result = BahmniProgramEnrollmentResource.getIdentifiers(program);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void shouldReturnFullRepresentationsForPatientAndIdentifiers() {
+        DelegatingResourceDescription desc = new BahmniProgramEnrollmentResource().getRepresentationDescription(new FullRepresentation());
+        assertEquals(Representation.FULL, desc.getProperties().get("patient").getRep());
+        assertEquals(Representation.FULL, desc.getProperties().get("identifiers").getRep());
+    }
+
+    @Test
+    public void shouldSetIdentifiersToRefRepWhenDefaultRepresentation() {
+        DelegatingResourceDescription desc = new BahmniProgramEnrollmentResource().getRepresentationDescription(new DefaultRepresentation());
+        assertEquals(Representation.REF, desc.getProperties().get("identifiers").getRep());
+    }
+
+    private PatientProgram programWithPatient() {
+        PatientProgram program = new PatientProgram();
+        program.setPatient(new Patient());
+        return program;
+    }
+
+    private PatientIdentifier identifierLinkedTo(PatientProgram program) {
+        PatientIdentifier identifier = new PatientIdentifier();
+        identifier.setPatientProgram(program);
+        return identifier;
+    }
+}

--- a/bahmnicore-omod/src/test/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResourceIdentifiersTest.java
+++ b/bahmnicore-omod/src/test/java/org/openmrs/module/bahmnicore/web/v1_0/resource/BahmniProgramEnrollmentResourceIdentifiersTest.java
@@ -5,7 +5,6 @@ import org.junit.runner.RunWith;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientProgram;
-import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;


### PR DESCRIPTION
JIRA → [BAH-4779](https://bahmni.atlassian.net/browse/BAH-4779)

## Key Changes

  - Added `getIdentifiers` property getter on `BahmniProgramEnrollmentResource` that returns only the active patient identifiers linked to the specific program enrollment
  - Exposed `identifiers` in `DefaultRepresentation` (REF) and `FullRepresentation` (FULL)
  - Exposed `patient` in `FullRepresentation` (FULL)

[BAH-4779]: https://bahmni.atlassian.net/browse/BAH-4779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ