### PR TITLE
BAH-4795 | Add Semgrep SAST CI workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,28 @@
+name: Semgrep SAST
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  schedule:
+    - cron: '24 13 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+      - run: semgrep scan --config auto --sarif --output semgrep.sarif
+        continue-on-error: true
+      - uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: semgrep.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -16,13 +16,16 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      # semgrep/semgrep:1.165.0 — pinned by digest; bump manually when needed
+      image: semgrep/semgrep@sha256:bd2ada83c7aa5a60e07d86ee84ba0c12282264781c8d783be5a912549a94394f
     if: github.actor != 'dependabot[bot]'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - run: semgrep scan --config auto --sarif --output semgrep.sarif
         continue-on-error: true
-      - uses: github/codeql-action/upload-sarif@v3
-        if: always()
+      - uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        if: always() && hashFiles('semgrep.sarif') != ''
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary

Adds `.github/workflows/semgrep.yml`. Runs [Semgrep Community Edition](https://docs.semgrep.dev/deployment/oss-deployment) static analysis on PRs, pushes to `master`, and weekly. Findings upload to the **Security tab** (Code Scanning) via SARIF.

Pilot for the org-wide rollout tracked in [BAH-4795](https://bahmni.atlassian.net/browse/BAH-4795) — this is the first of 14 repos. Once the workflow runs cleanly here, the same YAML will be added to the other 13.

## What it catches

OWASP-class bugs that the existing SonarCloud step misses: SQL injection, path traversal, XSS, command injection, insecure deserialization. ~2,000 community rules cover the auto-detected language set.

## Phase 1 — non-blocking

`continue-on-error: true` is set so existing findings on legacy code do **not** fail PRs. Findings still surface in the Security tab for review. A follow-up PR will remove that flag and add `--baseline-ref origin/master` once a baseline is triaged.

## Cost: \$0

- Semgrep Community Edition (LGPL-2.1), public registry rules — free for commercial + OSS
- No `SEMGREP_APP_TOKEN`, no Semgrep Cloud account
- GitHub Code Scanning — free for public repos

## Test plan

- [ ] Workflow appears in the Actions tab and runs on this PR
- [ ] Scan completes (success or non-zero exit — both are fine in phase 1)
- [ ] SARIF uploads to the Security tab (Code scanning alerts)
- [ ] Subsequent push to `master` triggers the workflow
- [ ] Weekly schedule appears under Actions → Semgrep SAST

[BAH-4795]: https://bahmni.atlassian.net/browse/BAH-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated Semgrep security scan to the CI/CD pipeline, generating SARIF results and uploading them to security checks on supported events, with safeguards for Dependabot activity and optional scan-failure tolerance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->