### PR TITLE
BAH-4769 | Submit test results not working for other locale except En

### DIFF
--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandler.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandler.java
@@ -78,7 +78,9 @@ public class BahmniConceptSearchHandler implements SearchHandler {
 
     /**
      * Returns list of unique locales based on the context.getParameter("locale") parameter
-     * <strong>Should</strong> return List of results for locales: If locale is specified, then return results for that locale.
+     * <strong>Should</strong> return List of results for locales: If locale is specified, then return results for that
+     * locale and the default locale (if different), so that fully-specified names stored in the default locale are
+     * always included in the candidate set.
      * If locale is not specified, then return results for logged in locale and default locale.
      */
 
@@ -88,7 +90,11 @@ public class BahmniConceptSearchHandler implements SearchHandler {
         List<Locale> localeList = new ArrayList<>();
 
         if (locale != null) {
-            localeList.add(LocaleUtility.fromSpecification(locale));
+            Locale requestedLocale = LocaleUtility.fromSpecification(locale);
+            localeList.add(requestedLocale);
+            if (!LocaleUtility.getDefaultLocale().equals(requestedLocale)) {
+                localeList.add(LocaleUtility.getDefaultLocale());
+            }
         } else {
             localeList.add(Context.getLocale());
             if (!LocaleUtility.getDefaultLocale().equals(Context.getLocale())) {

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
@@ -78,6 +78,9 @@ public class BahmniConceptSearchHandlerTest {
 
         List<Locale> localeList = new ArrayList<>();
         localeList.add(Locale.FRENCH);
+        if (!LocaleUtility.getDefaultLocale().equals(Locale.FRENCH)) {
+            localeList.add(LocaleUtility.getDefaultLocale());
+        }
 
         when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
         when(requestContext.getLimit()).thenReturn(10);
@@ -89,8 +92,36 @@ public class BahmniConceptSearchHandlerTest {
 
         verify(conceptService, times(1)).getConcepts("Nutritional Values", localeList, false, null, null, null, null, null, 0, null);
         assertEquals(1, searchResults.getPageOfResults().size());
-        assertEquals(1, localeList.size());
         assertEquals(new Integer(123) , searchResults.getPageOfResults().get(0).getId());
+    }
+
+    @Test
+    public void shouldIncludeDefaultLocale_whenNonDefaultLocaleIsSpecified() {
+        List<ConceptSearchResult> conceptSearchResults = new ArrayList<>();
+        ConceptSearchResult result = new ConceptSearchResult();
+        Concept concept = new Concept();
+        concept.setId(456);
+        ConceptName conceptNameFullySpecified = new ConceptName();
+        conceptNameFullySpecified.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
+        conceptNameFullySpecified.setName("Lab Samples");
+        concept.setNames(Collections.singleton(conceptNameFullySpecified));
+        result.setConcept(concept);
+        conceptSearchResults.add(result);
+
+        List<Locale> expectedLocaleList = new ArrayList<>();
+        expectedLocaleList.add(new Locale("es"));
+        expectedLocaleList.add(LocaleUtility.getDefaultLocale());
+
+        when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
+        when(requestContext.getLimit()).thenReturn(10);
+        when(requestContext.getParameter("locale")).thenReturn("es");
+        when(requestContext.getParameter("name")).thenReturn("Lab Samples");
+
+        NeedsPaging<Concept> searchResults = (NeedsPaging<Concept>) bahmniConceptSearchHandler.search(requestContext);
+
+        verify(conceptService, times(1)).getConcepts("Lab Samples", expectedLocaleList, false, null, null, null, null, null, 0, null);
+        assertEquals(1, searchResults.getPageOfResults().size());
+        assertEquals(new Integer(456), searchResults.getPageOfResults().get(0).getId());
     }
 
     @Test

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
@@ -110,7 +110,9 @@ public class BahmniConceptSearchHandlerTest {
 
         List<Locale> expectedLocaleList = new ArrayList<>();
         expectedLocaleList.add(new Locale("es"));
-        expectedLocaleList.add(LocaleUtility.getDefaultLocale());
+        if (!LocaleUtility.getDefaultLocale().equals(new Locale("es"))) {
+            expectedLocaleList.add(LocaleUtility.getDefaultLocale());
+        }
 
         when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
         when(requestContext.getLimit()).thenReturn(10);

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandlerTest.java
@@ -1,6 +1,7 @@
 package org.bahmni.module.bahmnicore.web.v1_0.search;
 
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -19,6 +20,7 @@ import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -65,6 +67,10 @@ public class BahmniConceptSearchHandlerTest {
 
     @Test
     public void shouldSearchByGivenLocale_whenLocaleIsSpecified() {
+        Assume.assumeFalse(
+                "Test exercises the non-default branch; skip if defaultLocale == fr",
+                LocaleUtility.getDefaultLocale().equals(Locale.FRENCH));
+
         List<ConceptSearchResult> conceptSearchResults = new ArrayList<>();
         ConceptSearchResult result =  new ConceptSearchResult();
         Concept concept = new Concept();
@@ -76,11 +82,8 @@ public class BahmniConceptSearchHandlerTest {
         result.setConcept(concept);
         conceptSearchResults.add(result);
 
-        List<Locale> localeList = new ArrayList<>();
-        localeList.add(Locale.FRENCH);
-        if (!LocaleUtility.getDefaultLocale().equals(Locale.FRENCH)) {
-            localeList.add(LocaleUtility.getDefaultLocale());
-        }
+        // Ordering matters: requested locale first, default second.
+        List<Locale> expectedLocaleList = Arrays.asList(Locale.FRENCH, LocaleUtility.getDefaultLocale());
 
         when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
         when(requestContext.getLimit()).thenReturn(10);
@@ -90,13 +93,18 @@ public class BahmniConceptSearchHandlerTest {
 
         NeedsPaging<Concept> searchResults = (NeedsPaging<Concept>) bahmniConceptSearchHandler.search(requestContext);
 
-        verify(conceptService, times(1)).getConcepts("Nutritional Values", localeList, false, null, null, null, null, null, 0, null);
+        verify(conceptService, times(1)).getConcepts("Nutritional Values", expectedLocaleList, false, null, null, null, null, null, 0, null);
         assertEquals(1, searchResults.getPageOfResults().size());
         assertEquals(new Integer(123) , searchResults.getPageOfResults().get(0).getId());
     }
 
     @Test
     public void shouldIncludeDefaultLocale_whenNonDefaultLocaleIsSpecified() {
+        Locale spanish = LocaleUtility.fromSpecification("es");
+        Assume.assumeFalse(
+                "Test exercises the non-default branch; skip if defaultLocale == es",
+                LocaleUtility.getDefaultLocale().equals(spanish));
+
         List<ConceptSearchResult> conceptSearchResults = new ArrayList<>();
         ConceptSearchResult result = new ConceptSearchResult();
         Concept concept = new Concept();
@@ -108,11 +116,8 @@ public class BahmniConceptSearchHandlerTest {
         result.setConcept(concept);
         conceptSearchResults.add(result);
 
-        List<Locale> expectedLocaleList = new ArrayList<>();
-        expectedLocaleList.add(new Locale("es"));
-        if (!LocaleUtility.getDefaultLocale().equals(new Locale("es"))) {
-            expectedLocaleList.add(LocaleUtility.getDefaultLocale());
-        }
+        // Ordering matters: requested locale first, default second.
+        List<Locale> expectedLocaleList = Arrays.asList(spanish, LocaleUtility.getDefaultLocale());
 
         when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
         when(requestContext.getLimit()).thenReturn(10);
@@ -124,6 +129,38 @@ public class BahmniConceptSearchHandlerTest {
         verify(conceptService, times(1)).getConcepts("Lab Samples", expectedLocaleList, false, null, null, null, null, null, 0, null);
         assertEquals(1, searchResults.getPageOfResults().size());
         assertEquals(new Integer(456), searchResults.getPageOfResults().get(0).getId());
+    }
+
+    @Test
+    public void shouldNotDuplicateDefaultLocale_whenRequestedLocaleEqualsDefault() {
+        Locale defaultLocale = LocaleUtility.getDefaultLocale();
+        Assume.assumeTrue(
+                "Test requires defaultLocale to round-trip via fromSpecification",
+                defaultLocale.equals(LocaleUtility.fromSpecification(defaultLocale.toString())));
+
+        List<ConceptSearchResult> conceptSearchResults = new ArrayList<>();
+        ConceptSearchResult result = new ConceptSearchResult();
+        Concept concept = new Concept();
+        concept.setId(789);
+        ConceptName conceptNameFullySpecified = new ConceptName();
+        conceptNameFullySpecified.setConceptNameType(ConceptNameType.FULLY_SPECIFIED);
+        conceptNameFullySpecified.setName("Lab Samples");
+        concept.setNames(Collections.singleton(conceptNameFullySpecified));
+        result.setConcept(concept);
+        conceptSearchResults.add(result);
+
+        List<Locale> expectedLocaleList = Collections.singletonList(defaultLocale);
+
+        when(conceptService.getConcepts(anyString(), anyList(), anyBoolean(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Integer.class), isNull())).thenReturn(conceptSearchResults);
+        when(requestContext.getLimit()).thenReturn(10);
+        when(requestContext.getParameter("locale")).thenReturn(defaultLocale.toString());
+        when(requestContext.getParameter("name")).thenReturn("Lab Samples");
+
+        NeedsPaging<Concept> searchResults = (NeedsPaging<Concept>) bahmniConceptSearchHandler.search(requestContext);
+
+        verify(conceptService, times(1)).getConcepts("Lab Samples", expectedLocaleList, false, null, null, null, null, null, 0, null);
+        assertEquals(1, searchResults.getPageOfResults().size());
+        assertEquals(new Integer(789), searchResults.getPageOfResults().get(0).getId());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- JIRA: [BAH-4769](https://bahmni.atlassian.net/browse/BAH-4769) — Lab Entry | Submit test results not working for other locale except En
- `BahmniConceptSearchHandler.getLocales` now also includes the default locale when the request specifies a non-default locale, mirroring the symmetric branch that already handles the "no locale specified" case
- Unblocks the UI submit-bundle flow for non-English locales (e.g. Spanish) by ensuring fully-specified concept names stored in the default locale are returned in the search response

## Why

`/openmrs/ws/rest/v1/concept?s=byFullySpecifiedName&locale=es&name=Lab Samples` returned empty because OpenMRS filtered `ConceptName` rows to the Spanish locale only. The Spanish name "Muestras de Laboratorio" does not match the fully-specified English name "Lab Samples", so the response was empty. The lab UI's validation layer treats an empty concept response as a failure and silently blocks the submit-bundle API call.

`byFullySpecifiedName` is by definition a canonical-name lookup; fully-specified names live in the default locale. Including the default locale in the candidate set is semantically correct and benefits every client of the endpoint.

## Test plan

- [x] Added `shouldIncludeDefaultLocale_whenNonDefaultLocaleIsSpecified` — verifies that for `locale=es&name=Lab Samples`, the default locale is added to the search list
- [x] Updated `shouldSearchByGivenLocale_whenLocaleIsSpecified` to expect both the specified locale and the default locale
- [x] Deployed locally to Bahmni Lite (`bahmni-lite-openmrs-1`) and verified the lab module Submit Test Results flow works in a non-English locale
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BAH-4769]: https://bahmni.atlassian.net/browse/BAH-4769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concept search locale handling so results are returned using both the requested locale and the system default locale when they differ, ensuring fully specified names stored in the default locale are included.

* **Tests**
  * Expanded locale-related test coverage to validate the exact locale list passed into the search logic, avoid duplicates when the requested locale equals the system default, and confirm paging/content behavior for each scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->