### PR TITLE
BSL-13,BSL-14 | Fix. Update Sonatype Maven Central publish version to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -565,7 +565,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>nexus-sonatype</publishingServerId>


### PR DESCRIPTION
This PR upgrades the Sonatype Maven central publishing plugin version to 0.11.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a build publishing plugin to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->