### PR TITLE
BAH 4923 | Adds handler for duplicate visit

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/exception/DuplicateVisitException.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/exception/DuplicateVisitException.java
@@ -1,0 +1,13 @@
+package org.bahmni.module.bahmnicore.exception;
+
+import org.openmrs.api.APIException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class DuplicateVisitException extends APIException {
+
+    public DuplicateVisitException(String message) {
+        super(message);
+    }
+}

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandler.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandler.java
@@ -28,7 +28,7 @@ public class DuplicateVisitSaveHandler implements SaveHandler<Visit> {
         }
 
         List<Visit> activeVisits = visitService.getActiveVisitsByPatient(visit.getPatient());
-        long now = new Date().getTime();
+        long now = currentDate.getTime();
         for (Visit activeVisit : activeVisits) {
             if (isRecentDuplicate(visit, activeVisit, now)) {
                 throw new DuplicateVisitException("A visit has already just been started for this patient at this location.");

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandler.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandler.java
@@ -1,0 +1,46 @@
+package org.bahmni.module.bahmnicore.handler;
+
+import org.bahmni.module.bahmnicore.exception.DuplicateVisitException;
+import org.openmrs.User;
+import org.openmrs.Visit;
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.VisitService;
+import org.openmrs.api.handler.SaveHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.List;
+
+@Component
+@Handler(supports = {Visit.class})
+public class DuplicateVisitSaveHandler implements SaveHandler<Visit> {
+
+    private static final long DUPLICATE_VISIT_WINDOW_MILLIS = 10000;
+
+    @Autowired
+    private VisitService visitService;
+
+    @Override
+    public void handle(Visit visit, User currentUser, Date currentDate, String reason) {
+        if (visit.getVisitId() != null || visit.getPatient() == null || visit.getVisitType() == null) {
+            return;
+        }
+
+        List<Visit> activeVisits = visitService.getActiveVisitsByPatient(visit.getPatient());
+        long now = new Date().getTime();
+        for (Visit activeVisit : activeVisits) {
+            if (isRecentDuplicate(visit, activeVisit, now)) {
+                throw new DuplicateVisitException("A visit has already just been started for this patient at this location.");
+            }
+        }
+    }
+
+    private boolean isRecentDuplicate(Visit newVisit, Visit existingVisit, long now) {
+        boolean sameVisitType = existingVisit.getVisitType() != null && existingVisit.getVisitType().equals(newVisit.getVisitType());
+        boolean sameLocation = existingVisit.getLocation() != null && existingVisit.getLocation().equals(newVisit.getLocation());
+        boolean recentlyCreated = existingVisit.getDateCreated() != null
+                && (now - existingVisit.getDateCreated().getTime()) < DUPLICATE_VISIT_WINDOW_MILLIS;
+        return sameVisitType && sameLocation && recentlyCreated;
+    }
+}

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandlerTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/handler/DuplicateVisitSaveHandlerTest.java
@@ -1,0 +1,131 @@
+package org.bahmni.module.bahmnicore.handler;
+
+import org.bahmni.module.bahmnicore.exception.DuplicateVisitException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.openmrs.Location;
+import org.openmrs.Patient;
+import org.openmrs.Visit;
+import org.openmrs.VisitType;
+import org.openmrs.api.VisitService;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DuplicateVisitSaveHandlerTest {
+
+    @InjectMocks
+    private DuplicateVisitSaveHandler handler;
+
+    @Mock
+    private VisitService visitService;
+
+    private Patient patient;
+    private VisitType visitType;
+    private Location location;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        patient = new Patient();
+        visitType = new VisitType();
+        visitType.setId(1);
+        location = new Location();
+        location.setId(1);
+    }
+
+    private Visit newVisit() {
+        Visit visit = new Visit();
+        visit.setPatient(patient);
+        visit.setVisitType(visitType);
+        visit.setLocation(location);
+        return visit;
+    }
+
+    @Test
+    public void shouldRejectWhenAnActiveVisitOfSameTypeAndLocationWasJustCreated() {
+        Visit newVisit = newVisit();
+
+        Visit existingVisit = newVisit();
+        existingVisit.setId(1);
+        existingVisit.setDateCreated(new Date());
+        Mockito.when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(existingVisit));
+
+        try {
+            handler.handle(newVisit, null, new Date(), null);
+            fail("Expected a DuplicateVisitException to be thrown for the duplicate visit");
+        } catch (DuplicateVisitException e) {
+            assertTrue(e.getMessage().contains("already"));
+        }
+    }
+
+    @Test
+    public void shouldNotRejectWhenNoActiveVisitsExist() {
+        Visit newVisit = newVisit();
+        Mockito.when(visitService.getActiveVisitsByPatient(patient)).thenReturn(new ArrayList<Visit>());
+
+        handler.handle(newVisit, null, new Date(), null);
+    }
+
+    @Test
+    public void shouldNotRejectWhenExistingActiveVisitIsOfDifferentType() {
+        Visit newVisit = newVisit();
+
+        VisitType differentVisitType = new VisitType();
+        differentVisitType.setId(2);
+
+        Visit existingVisit = newVisit();
+        existingVisit.setId(1);
+        existingVisit.setVisitType(differentVisitType);
+        existingVisit.setDateCreated(new Date());
+        Mockito.when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(existingVisit));
+
+        handler.handle(newVisit, null, new Date(), null);
+    }
+
+    @Test
+    public void shouldNotRejectWhenExistingActiveVisitIsAtDifferentLocation() {
+        Visit newVisit = newVisit();
+
+        Location differentLocation = new Location();
+        differentLocation.setId(2);
+
+        Visit existingVisit = newVisit();
+        existingVisit.setId(1);
+        existingVisit.setLocation(differentLocation);
+        existingVisit.setDateCreated(new Date());
+        Mockito.when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(existingVisit));
+
+        handler.handle(newVisit, null, new Date(), null);
+    }
+
+    @Test
+    public void shouldNotRejectWhenExistingActiveVisitWasCreatedLongAgo() {
+        Visit newVisit = newVisit();
+
+        Visit existingVisit = newVisit();
+        existingVisit.setId(1);
+        existingVisit.setDateCreated(new Date(System.currentTimeMillis() - 60000));
+        Mockito.when(visitService.getActiveVisitsByPatient(patient)).thenReturn(Arrays.asList(existingVisit));
+
+        handler.handle(newVisit, null, new Date(), null);
+    }
+
+    @Test
+    public void shouldNotHandleWhenVisitIsAlreadyPersisted() {
+        Visit existingVisit = newVisit();
+        existingVisit.setId(1);
+
+        handler.handle(existingVisit, null, new Date(), null);
+
+        Mockito.verifyNoInteractions(visitService);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental duplicate visits when an active visit for the same patient, type, and location was created within the previous 10 seconds.
  * Duplicate submissions now return a clear validation error.
  * Existing visits and visits with differing details continue to be accepted appropriately.

* **Tests**
  * Added coverage for duplicate detection and valid visit creation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->