### PR TITLE
BAH-4989 | Guard v2 patient image API with Get Patient Photo privilege

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/security/PrivilegeConstants.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/security/PrivilegeConstants.java
@@ -3,4 +3,5 @@ package org.bahmni.module.bahmnicore.security;
 public class PrivilegeConstants {
     public static final String DELETE_PATIENT_DOCUMENT_PRIVILEGE = "Delete Patient Document";
     public static final String IMPORT_CSV_FILE_PRIVILEGE = "Import CSV Files";
+    public static final String GET_PATIENT_PHOTO = "Get Patient Photo";
 }

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
@@ -2,6 +2,7 @@ package org.bahmni.module.bahmnicore.web.v2_0.controller;
 
 import org.bahmni.module.bahmnicore.security.PrivilegeConstants;
 import org.bahmni.module.bahmnicore.service.PatientDocumentService;
+import org.bahmni.module.bahmnicore.util.WebUtils;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
 import org.openmrs.module.webservices.rest.web.RestConstants;
@@ -33,7 +34,7 @@ public class BahmniPatientImageController extends BaseRestController {
         UserContext userContext = Context.getUserContext();
         if (userContext.isAuthenticated()) {
             if (!userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)) {
-                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+                return new ResponseEntity<>(WebUtils.wrapErrorResponse(null, "Insufficient privilege"), HttpStatus.FORBIDDEN);
             }
             return patientDocumentService.retriveImageWithoutDefault(patientUuid);
         }

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
@@ -34,7 +34,7 @@ public class BahmniPatientImageController extends BaseRestController {
         UserContext userContext = Context.getUserContext();
         if (userContext.isAuthenticated()) {
             if (!userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)) {
-                return new ResponseEntity<>(WebUtils.wrapErrorResponse(null, "User lacks '" + PrivilegeConstants.GET_PATIENT_PHOTO + "' privilege and is unable to view the patient photo"), HttpStatus.FORBIDDEN);
+                return new ResponseEntity<>(WebUtils.wrapErrorResponse(null, "User doesn't have " + PrivilegeConstants.GET_PATIENT_PHOTO + " privilege"), HttpStatus.FORBIDDEN);
             }
             return patientDocumentService.retriveImageWithoutDefault(patientUuid);
         }

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
@@ -1,5 +1,6 @@
 package org.bahmni.module.bahmnicore.web.v2_0.controller;
 
+import org.bahmni.module.bahmnicore.security.PrivilegeConstants;
 import org.bahmni.module.bahmnicore.service.PatientDocumentService;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
@@ -31,6 +32,9 @@ public class BahmniPatientImageController extends BaseRestController {
     public ResponseEntity<Object> getImage(@RequestParam(value = "patientUuid", required = true) String patientUuid) {
         UserContext userContext = Context.getUserContext();
         if (userContext.isAuthenticated()) {
+            if (!userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)) {
+                return new ResponseEntity<Object>(new Object(), HttpStatus.FORBIDDEN);
+            }
             return patientDocumentService.retriveImageWithoutDefault(patientUuid);
         }
         return new ResponseEntity<Object>(new Object(), HttpStatus.UNAUTHORIZED);

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
@@ -34,7 +34,7 @@ public class BahmniPatientImageController extends BaseRestController {
         UserContext userContext = Context.getUserContext();
         if (userContext.isAuthenticated()) {
             if (!userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)) {
-                return new ResponseEntity<>(WebUtils.wrapErrorResponse(null, "Insufficient privilege"), HttpStatus.FORBIDDEN);
+                return new ResponseEntity<>(WebUtils.wrapErrorResponse(null, "User lacks '" + PrivilegeConstants.GET_PATIENT_PHOTO + "' privilege and is unable to view the patient photo"), HttpStatus.FORBIDDEN);
             }
             return patientDocumentService.retriveImageWithoutDefault(patientUuid);
         }

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageController.java
@@ -33,10 +33,10 @@ public class BahmniPatientImageController extends BaseRestController {
         UserContext userContext = Context.getUserContext();
         if (userContext.isAuthenticated()) {
             if (!userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)) {
-                return new ResponseEntity<Object>(new Object(), HttpStatus.FORBIDDEN);
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
             }
             return patientDocumentService.retriveImageWithoutDefault(patientUuid);
         }
-        return new ResponseEntity<Object>(new Object(), HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
     }
 }

--- a/bahmnicore-omod/src/main/resources/config.xml
+++ b/bahmnicore-omod/src/main/resources/config.xml
@@ -106,6 +106,10 @@
         <name>Import CSV Files</name>
         <description>Ability to import data from CSV Files</description>
     </privilege>
+    <privilege>
+        <name>Get Patient Photo</name>
+        <description>Ability to view patient photo</description>
+    </privilege>
 
     <advice>
         <point>org.openmrs.module.bahmniemrapi.encountertransaction.service.BahmniEncounterTransactionService</point>

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageControllerTest.java
@@ -1,5 +1,6 @@
 package org.bahmni.module.bahmnicore.web.v2_0.controller;
 
+import org.bahmni.module.bahmnicore.security.PrivilegeConstants;
 import org.bahmni.module.bahmnicore.service.PatientDocumentService;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,8 +42,9 @@ public class BahmniPatientImageControllerTest {
     }
 
     @Test
-    public void shouldRetrieveImageWithoutDefaultWhenUserIsAuthenticated() {
+    public void shouldRetrieveImageWithoutDefaultWhenUserIsAuthenticatedAndHasPrivilege() {
         Mockito.when(userContext.isAuthenticated()).thenReturn(true);
+        Mockito.when(userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)).thenReturn(true);
         when(patientDocumentService.retriveImageWithoutDefault(anyString())).thenReturn(new ResponseEntity<Object>(new Object(), HttpStatus.OK));
         String patientUuid = "patientUuid";
 
@@ -65,8 +67,21 @@ public class BahmniPatientImageControllerTest {
     }
 
     @Test
+    public void shouldReturnForbiddenWhenUserIsAuthenticatedButLacksPrivilege() {
+        Mockito.when(userContext.isAuthenticated()).thenReturn(true);
+        Mockito.when(userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)).thenReturn(false);
+        String patientUuid = "patientUuid";
+
+        ResponseEntity<Object> responseEntity = bahmniPatientImageController.getImage(patientUuid);
+
+        verify(patientDocumentService, never()).retriveImageWithoutDefault(patientUuid);
+        assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+    }
+
+    @Test
     public void shouldReturnNotFoundWhenPatientImageDoesNotExist() {
         Mockito.when(userContext.isAuthenticated()).thenReturn(true);
+        Mockito.when(userContext.hasPrivilege(PrivilegeConstants.GET_PATIENT_PHOTO)).thenReturn(true);
         when(patientDocumentService.retriveImageWithoutDefault(anyString())).thenReturn(new ResponseEntity<Object>(new Object(), HttpStatus.NOT_FOUND));
         String patientUuid = "patientUuid";
 

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v2_0/controller/BahmniPatientImageControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -76,6 +77,7 @@ public class BahmniPatientImageControllerTest {
 
         verify(patientDocumentService, never()).retriveImageWithoutDefault(patientUuid);
         assertEquals(HttpStatus.FORBIDDEN, responseEntity.getStatusCode());
+        assertTrue(responseEntity.getBody().toString().contains("User doesn't have Get Patient Photo privilege"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Added `GET_PATIENT_PHOTO = "Get Patient Photo"` privilege constant to `PrivilegeConstants.java`
- Declared privilege in `config.xml` so OpenMRS registers it on module startup
- Guarded `GET /rest/v2/patientImage` with privilege check:
  - `401 UNAUTHORIZED` — unauthenticated request
  - `403 FORBIDDEN` — authenticated but lacks `Get Patient Photo` privilege, with descriptive error message: `"User lacks 'Get Patient Photo' privilege and is unable to view the patient photo"`
  - `200 OK` — authenticated and privileged (image returned) or `404 NOT_FOUND` (no photo on file)
- Fixed serialization issue: replaced `new ResponseEntity<>(new Object(), status)` with `new ResponseEntity<>(status)` or proper error body to avoid `HttpMediaTypeNotAcceptableException`
- Updated `BahmniPatientImageControllerTest` with tests for all three access scenarios

## Test plan
- [ ] Unauthenticated request returns 401
- [ ] Authenticated user without `Get Patient Photo` privilege returns 403 with error message
- [ ] Authenticated user with `Get Patient Photo` privilege (or System Developer role) returns 200/404
- [ ] `Get Patient Photo` privilege appears in OpenMRS admin after module reload
- [ ] Run `BahmniPatientImageControllerTest`

Jira: https://bahmni.atlassian.net/browse/BAH-4989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **Get Patient Photo** privilege for controlling access to patient photos.

* **Bug Fixes**
  * Improved authorization feedback by identifying the required privilege when access to a patient photo is denied.
  * Unauthorized requests continue to receive the appropriate access-denied response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->