### PR TITLE
BAH-4996 | Migrate Stopped Order Reason concept to a set with Refused To Take member

### DIFF
--- a/bahmnicore-omod/src/main/resources/V1_101__StoppedOrderReasonConceptSet.sql
+++ b/bahmnicore-omod/src/main/resources/V1_101__StoppedOrderReasonConceptSet.sql
@@ -17,7 +17,10 @@ FROM concept_datatype dt, concept_class cc
 WHERE dt.name = 'N/A' AND cc.name = 'Misc'
   AND @refusedToTakeConceptId IS NULL;
 
-SET @refusedToTakeConceptId := IFNULL(@refusedToTakeConceptId, (SELECT MAX(concept_id) FROM concept));
+SET @refusedToTakeConceptId := IFNULL(
+    @refusedToTakeConceptId,
+    IF(ROW_COUNT() > 0, LAST_INSERT_ID(), NULL)
+);
 
 INSERT INTO concept_name (concept_id, name, locale, locale_preferred, creator, date_created, concept_name_type, uuid)
 SELECT @refusedToTakeConceptId, 'Refused To Take', 'en', 1, 1, now(), 'FULLY_SPECIFIED', uuid()

--- a/bahmnicore-omod/src/main/resources/V1_101__StoppedOrderReasonConceptSet.sql
+++ b/bahmnicore-omod/src/main/resources/V1_101__StoppedOrderReasonConceptSet.sql
@@ -1,0 +1,38 @@
+-- BAH-4689: Migrate "Stopped Order Reason" concept to a set and add "Refused To Take" as a member
+
+SET @stoppedOrderReasonConceptId := (
+  SELECT concept_id FROM concept_name WHERE name = 'Stopped Order Reason' AND concept_name_type = 'FULLY_SPECIFIED' LIMIT 1
+);
+
+UPDATE concept SET is_set = 1 WHERE concept_id = @stoppedOrderReasonConceptId AND is_set = 0;
+
+SET @refusedToTakeConceptId := (
+  SELECT concept_id FROM concept_name WHERE name = 'Refused To Take' AND concept_name_type = 'FULLY_SPECIFIED' LIMIT 1
+);
+
+-- Create the "Refused To Take" concept if it does not already exist
+INSERT INTO concept (datatype_id, class_id, is_set, creator, date_created, uuid)
+SELECT dt.concept_datatype_id, cc.concept_class_id, 0, 1, now(), uuid()
+FROM concept_datatype dt, concept_class cc
+WHERE dt.name = 'N/A' AND cc.name = 'Misc'
+  AND @refusedToTakeConceptId IS NULL;
+
+SET @refusedToTakeConceptId := IFNULL(@refusedToTakeConceptId, (SELECT MAX(concept_id) FROM concept));
+
+INSERT INTO concept_name (concept_id, name, locale, locale_preferred, creator, date_created, concept_name_type, uuid)
+SELECT @refusedToTakeConceptId, 'Refused To Take', 'en', 1, 1, now(), 'FULLY_SPECIFIED', uuid()
+WHERE @refusedToTakeConceptId IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM concept_name WHERE concept_id = @refusedToTakeConceptId AND concept_name_type = 'FULLY_SPECIFIED'
+  );
+
+-- Add "Refused To Take" as a member of the "Stopped Order Reason" set if not already linked
+INSERT INTO concept_set (concept_id, concept_set, sort_weight, creator, date_created, uuid)
+SELECT @refusedToTakeConceptId, @stoppedOrderReasonConceptId,
+  IFNULL((SELECT MAX(sort_weight) FROM concept_set WHERE concept_set = @stoppedOrderReasonConceptId), 0) + 1,
+  1, now(), uuid()
+WHERE @stoppedOrderReasonConceptId IS NOT NULL
+  AND @refusedToTakeConceptId IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM concept_set WHERE concept_id = @refusedToTakeConceptId AND concept_set = @stoppedOrderReasonConceptId
+  );

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4713,4 +4713,9 @@
         </sql>
     </changeSet>
 
+    <changeSet id="bahmni-core-202608121300" author="Rohit V">
+        <comment>BAH-4689: Migrate "Stopped Order Reason" concept to a set and add "Refused To Take" as a member</comment>
+        <sqlFile path="V1_101__StoppedOrderReasonConceptSet.sql"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Part of [BAH-4996](https://bahmni.atlassian.net/browse/BAH-4996) (legacy medication order note migration). Old and new Bahmni need a shared coded stop-reason for discontinuing a drug order, so this adds a standalone Liquibase changeset (`bahmni-core-202608121300`) that:

- Marks the `Stopped Order Reason` concept as a set (`is_set = 1`)
- Creates the `Refused To Take` concept if it doesn't already exist
- Links `Refused To Take` as a member of the `Stopped Order Reason` set

This lets `order_reason` on a `DISCONTINUE` drug order reference `Refused To Take` as a coded stop reason, which the `bahmni-scripts` migration in BAH-4996 depends on to derive `order_reason_non_coded` display text.

## Why a Liquibase changeset

Unlike the rest of BAH-4996 (which is a standalone DB script per its acceptance criteria), this concept-dictionary change is core reference-data setup and belongs in the module's own migration path, consistent with how other concept/concept-set changes are added in this repo.

## Idempotency

All statements are guarded (`NOT EXISTS`, `IS NULL`, `is_set = 0`), so re-running against an already-migrated database is a no-op — verified by re-running the changeset against a DB where it had already applied.

## Testing

Verified end-to-end in a local Docker OpenMRS instance:
- Reset `is_set` and removed the set-link, then loaded the built module and confirmed the changeset ran and correctly recreated both
- Confirmed the changeset registers in `liquibasechangelog` and is skipped (no-op) on subsequent restarts
- Confirmed the module starts cleanly with no bean-wiring errors after the change

## Test plan for reviewers

- [ ] Deploy the built `bahmnicore` module against a DB with the pre-existing `Stopped Order Reason` concept
- [ ] Confirm `concept.is_set = 1` for `Stopped Order Reason` after startup
- [ ] Confirm `Refused To Take` exists and is linked via `concept_set`
- [ ] Restart again and confirm the changeset does not re-run or duplicate the set-link

[BAH-4996]: https://bahmni.atlassian.net/browse/BAH-4996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Refused To Take” as an available stopped-order reason.
  - Converted “Stopped Order Reason” into a concept set, enabling multiple selectable reasons.
- **Improvements**
  - Prevented duplicate concepts, names, and set memberships during the update.
  - Preserved consistent ordering when adding the new stopped-order reason.
  - Improved upgrade reliability by safely identifying newly created concepts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->