### PR TITLE
BAH-5026 | Drop the weekly cron from the Semgrep workflow

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
   push:
     branches: [main, master]
-  schedule:
-    - cron: '24 13 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes the `schedule:` trigger from `.github/workflows/semgrep.yml`. Two lines, no other change.

### Why

GitHub disables a scheduled workflow in a public repo after 60 days with no repository activity. Two details matter:

1. The disable applies to the whole workflow, not just the cron. `pull_request` and `push` stop firing too, so Semgrep stops running on every PR.
2. GitHub never re-enables it. Activity resuming does not undo it.

This already happened to two repos from this rollout. `semgrep.yml` was in state `disabled_inactivity` on Bahmni/bahmni-api-test-automation and Bahmni/openmrs-module-bedmanagement, so Semgrep had stopped running on their PRs entirely. Both have been re-enabled, and they would trip again in another 60 dormant days with the cron still in place.

### What is unaffected

* Scanning on every pull request, and on push to the default branch. This is where the coverage comes from.
* `workflow_dispatch`, so an on-demand full scan is still one click in the Actions tab.

### Diff

```
 on:
   pull_request:
   push:
     branches: [main, master]
-  schedule:
-    - cron: '24 13 * * 1'
   workflow_dispatch:
```

Ticket: https://bahmni.atlassian.net/browse/BAH-5026


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the weekly scheduled security scan.
  * Pull request, push, and manual scan triggers remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->