### PR TITLE
BAH-5041 | Fix path traversal on v2 patientImage endpoint

### DIFF
--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/PatientDocumentServiceImpl.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/service/impl/PatientDocumentServiceImpl.java
@@ -209,6 +209,9 @@ public class PatientDocumentServiceImpl implements PatientDocumentService {
     @Override
     public ResponseEntity<Object> retriveImageWithoutDefault(String patientUuid) {
         File file = getPatientImageFileWithoutDefault(patientUuid);
+        if (file == null) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
         return readImage(file);
     }
 
@@ -261,7 +264,12 @@ public class PatientDocumentServiceImpl implements PatientDocumentService {
     }
 
     private File getPatientImageFileWithoutDefault(String patientUuid) {
-        return new File(String.format("%s/%s.%s", BahmniCoreProperties.getProperty("bahmnicore.images.directory"), patientUuid, patientImagesFormat));
+        Path base = Paths.get(BahmniCoreProperties.getProperty("bahmnicore.images.directory")).toAbsolutePath().normalize();
+        Path resolved = base.resolve(patientUuid + "." + patientImagesFormat).normalize();
+        if (!resolved.startsWith(base)) {
+            return null;
+        }
+        return resolved.toFile();
     }
 
     private ResponseEntity<Object> readImage(File file) {

--- a/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/PatientDocumentServiceImplTest.java
+++ b/bahmnicore-api/src/test/java/org/bahmni/module/bahmnicore/service/impl/PatientDocumentServiceImplTest.java
@@ -90,6 +90,17 @@ public class PatientDocumentServiceImplTest {
     }
 
     @Test
+    public void shouldReturn404WhenPathTraversalAttemptedViaPatientUuidOnV2() {
+        PowerMockito.mockStatic(BahmniCoreProperties.class);
+        when(BahmniCoreProperties.getProperty("bahmnicore.images.directory")).thenReturn("/bahmni_data/patient_images");
+        patientDocumentService = new PatientDocumentServiceImpl();
+
+        ResponseEntity<Object> responseEntity = patientDocumentService.retriveImageWithoutDefault("../../../../tmp/secret");
+
+        assertEquals(404, responseEntity.getStatusCode().value());
+    }
+
+    @Test
     public void shouldGetImageNotFoundForIfNoImageCapturedForPatientAndNoDefaultImageNotPresent() throws Exception {
         final FileInputStream fileInputStreamMock = PowerMockito.mock(FileInputStream.class);
         PowerMockito.whenNew(FileInputStream.class).withArguments(Matchers.anyString()).thenReturn(fileInputStreamMock);


### PR DESCRIPTION
## Summary

Fixes path traversal vulnerability on the `GET /openmrs/ws/rest/v2/patientImage` endpoint (BAH-5041).

`patientUuid` was concatenated directly into the filesystem path inside `getPatientImageFileWithoutDefault()` without any normalization or containment check, allowing a `../`-traversal payload to read `.jpeg` files outside the configured images directory.

**Attack vector (before fix):**
```
GET /openmrs/ws/rest/v2/patientImage?patientUuid=../../../../tmp/secret
→ reads /tmp/secret.jpeg
```

**Fix:** Apply `Path.normalize().startsWith(base)` containment validation — the same pattern already used in `validateFileToBeDeleted()` and `buildAndValidateRelativePath()` in the same class. Returns `null` on traversal; `retriveImageWithoutDefault()` maps that to HTTP 404.

## Changes

- `PatientDocumentServiceImpl.java` — `getPatientImageFileWithoutDefault()` now validates the resolved path stays within the configured images directory; returns `null` if not
- `PatientDocumentServiceImpl.java` — `retriveImageWithoutDefault()` handles `null` file → 404
- `PatientDocumentServiceImplTest.java` — adds test asserting path traversal attempt returns 404

## Test plan

- [ ] `PatientDocumentServiceImplTest#shouldReturn404WhenPathTraversalAttemptedViaPatientUuidOnV2` passes
- [ ] Valid patient UUID still returns image as before
- [ ] `curl` with `patientUuid=../../../../tmp/secret` returns 404 (not file contents)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patient image requests now return a clear 404 response when no image is found.
  * Improved protection against path traversal when retrieving patient images, preventing access outside the configured image directory.

* **Tests**
  * Added coverage to verify that malicious image paths are rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->