### PR TITLE
BAH-5053 | Fix. maxDocumentSize limit overflow on the upload document…

### DIFF
--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/VisitDocumentController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/VisitDocumentController.java
@@ -77,7 +77,9 @@ public class VisitDocumentController extends BaseRestController {
             if (!StringUtils.isEmpty(maxDocumentSize)) {
                 Long maxDocumentSizeMb = Long.parseLong(maxDocumentSize);
                 Long maxDocumentSizeBytes = maxDocumentSizeMb * 1024 * 1024;
-                if (document.getContent().length() > maxDocumentSizeBytes) {
+                // getContent() is base64, which is 4/3 the size of the file it encodes.
+                // Convert back to decoded bytes so the limit means what it says.
+                if (document.getContent().length() * 3L / 4 > maxDocumentSizeBytes) {
                     logger.warn("Uploaded document size is greater than the maximum size " + maxDocumentSizeMb + "MB");
                     savedDocument.put("maxDocumentSizeMB", maxDocumentSizeMb);
                     return new ResponseEntity<>(savedDocument, HttpStatus.PAYLOAD_TOO_LARGE);

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/VisitDocumentControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/VisitDocumentControllerTest.java
@@ -286,4 +286,29 @@ public class VisitDocumentControllerTest {
 
         verify(patientDocumentService, times(1)).saveDocument(1, "consultation", base64Content, "jpeg", document.getFileType(), document.getFileName());
     }
+
+    @Test
+    public void shouldSaveDocumentWhoseDecodedSizeIsUnderLimitEvenIfBase64PayloadExceedsIt() throws Exception {
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getPatientService()).thenReturn(patientService);
+
+        Patient patient = new Patient();
+        patient.setId(1);
+        patient.setUuid("patient-uuid");
+        when(patientService.getPatientByUuid("patient-uuid")).thenReturn(patient);
+
+        when(administrationService.getGlobalProperty("bahmni.encounterType.default")).thenReturn("consultation");
+
+        Document document = new Document("abcd", "jpeg", null, "patient-uuid", "image", "file-name");
+
+        byte[] content = new byte[6 * 1024 * 1024];
+        String base64Content = Base64.getEncoder().encodeToString(content);
+        document.setContent(base64Content);
+
+        ResponseEntity<HashMap<String, Object>> responseEntity = visitDocumentController.saveDocument(document);
+
+        Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+
+        verify(patientDocumentService, times(1)).saveDocument(1, "consultation", base64Content, "jpeg", document.getFileType(), document.getFileName());
+    }
 }


### PR DESCRIPTION
Description: 
Uploading a document smaller than DOCUMENT_MAX_SIZE_MB fails with 413 PAYLOAD_TOO_LARGE. The size check compares the base64-encoded payload against the configured byte limit instead of the decoded file size. Because base64 inflates content by 4/3, the effective cap is 75% of whatever is configured — a setting of 5 MB rejects any file over 3.75 MiB.

Steps to reproduce:
1. Set DOCUMENT_MAX_SIZE_MB=5 on the openmrs container and restart.
2. Registration → open a patient → Document Upload.
3. Attach a PDF of ~4.4 MB (anything between 3.75 MiB and 5 MiB).
4. Upload fails.


Expected: upload succeeds — the file is under the configured 5 MB limit.

Root cause: VisitDocumentController.saveDocument (VisitDocumentController.java:80) evaluates document.getContent().length() > maxDocumentSizeBytes, where getContent() is the base64 string. Worked example from a real failing file: a 4,573,183-byte PDF (4.361 MiB) encodes to 6,097,580 base64 characters (5.815 MiB), which exceeds the 5,242,880-byte threshold by 854,700 — even though the file itself is 669,697 bytes under it.


Fix: convert the base64 length to decoded bytes before comparing — document.getContent().length() * 3L / 4 > maxDocumentSizeBytes. One line; 3L avoids int overflow on large payloads. DOCUMENT_MAX_SIZE_MB then means what it says, and matches the frontend's own 5 MiB gate on raw file.size, so no configuration change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected document upload size validation to measure decoded file content rather than Base64-encoded payload size.
  * Valid uploads that are within the configured limit are now accepted, even when encoding increases the payload size.

* **Tests**
  * Added coverage for uploads whose decoded size is within the allowed limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->