### PR TITLE
BAH-5021 | Bump version to 2.2.0-SNAPSHOT

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>admin</artifactId>

--- a/bahmni-emr-api/pom.xml
+++ b/bahmni-emr-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bahmni-mapping/pom.xml
+++ b/bahmni-mapping/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bahmni-mapping</artifactId>
     <packaging>jar</packaging>

--- a/bahmni-test-commons/pom.xml
+++ b/bahmni-test-commons/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bahmnicore-api/pom.xml
+++ b/bahmnicore-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-api</artifactId>
     <packaging>jar</packaging>

--- a/bahmnicore-omod/pom.xml
+++ b/bahmnicore-omod/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-omod</artifactId>
     <packaging>jar</packaging>

--- a/bahmnicore-ui/pom.xml
+++ b/bahmnicore-ui/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>bahmnicore-ui</artifactId>
     <packaging>jar</packaging>

--- a/obs-relation/pom.xml
+++ b/obs-relation/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>obs-relationship</artifactId>
     <packaging>jar</packaging>

--- a/openmrs-elis-atomfeed-client-omod/pom.xml
+++ b/openmrs-elis-atomfeed-client-omod/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>openelis-atomfeed-client-omod</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.bahmni.module</groupId>
     <artifactId>bahmni</artifactId>
-    <version>2.1.0</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Bahmni EMR Core</name>
     <url>https://github.com/Bahmni/bahmni-core.git</url>

--- a/reference-data/api/pom.xml
+++ b/reference-data/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reference-data/omod/pom.xml
+++ b/reference-data/omod/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>reference-data</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/reference-data/pom.xml
+++ b/reference-data/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.bahmni.module</groupId>
         <artifactId>bahmni</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>reference-data</artifactId>
     <packaging>pom</packaging>

--- a/vagrant-deploy/pom.xml
+++ b/vagrant-deploy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>bahmni</artifactId>
         <groupId>org.bahmni.module</groupId>
-        <version>2.1.0</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Bump development version to 2.2.0-SNAPSHOT after the 2.1.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project and module version references from `2.1.0` to `2.2.0-SNAPSHOT`.
  - Aligns all components with the upcoming 2.2.0 snapshot release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->